### PR TITLE
XSS fixes

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,14 +21,14 @@ class HttpRequestHandler(aiohttp.server.ServerHttpProtocol):
     # Reference patterns
     patterns = {
         re.compile('(/index.html|/)'): dict(name='index', order=1),
-        re.compile('.*(=.*(http(s){0,1}|ftp(s){0,1}):).*', re.IGNORECASE): dict(name='rfi', order=2),
+        re.compile('.*(=(http(s){0,1}|ftp(s){0,1}):).*', re.IGNORECASE): dict(name='rfi', order=2),
         re.compile('.*(select|drop|update|union|insert|alter|declare|cast)( |\().*', re.IGNORECASE): dict(
             name='sqli', order=2
         ),
         re.compile('.*(\/\.\.)*(home|proc|usr|etc)\/.*'): dict(
             name='lfi', order=2
         ),
-        re.compile('.*<(.|\n)*?>'): dict(name='xss', order=2)
+        re.compile('.*<(.|\n)*?>'): dict(name='xss', order=3)
 
     }
 
@@ -84,6 +84,7 @@ class HttpRequestHandler(aiohttp.server.ServerHttpProtocol):
                     detection['payload'] = rfi_emulation_result
                 if detection['name'] == 'xss':
                     xss_result = self.xss_emulator.handle(session, path)
+                    detection['payload'] = xss_result
                 if detection['name'] == 'lfi':
                     lfi_result = self.lfi_emulator.handle(path)
                     detection['payload'] = lfi_result

--- a/xss_emulator.py
+++ b/xss_emulator.py
@@ -12,24 +12,27 @@ class XssEmulator:
                 val = urllib.parse.unquote(val)
                 xss = re.match(r'.*<(.*)>.*', val)
                 if xss:
-                    value += val if not value else '\n'+val
+                    value += val if not value else '\n' + val
         return value
 
     def get_xss_result(self, session, val):
         result = None
-        injectable_page = '/index.html'
+        injectable_page = None
         if session:
             injectable_page = self.set_xss_page(session)
+        if injectable_page is None:
+            injectable_page = '/index.html'
         if val:
             result = dict(name='xss', value=val,
                           page=injectable_page)
         return result
 
     def set_xss_page(self, session):
+        injectable_page = None
         for page in reversed(session.paths):
             if mimetypes.guess_type(page['path'])[0] == 'text/html':
                 injectable_page = page['path']
-                return injectable_page
+        return injectable_page
 
     def handle(self, session, value, raw_data=None):
         xss_result = None


### PR DESCRIPTION
- change xss order to avoid wrong detection
- change rfi patternt (to avoid wrong detection)
- add xss payload to the result, 
- fix injectable page (if session paths contains only ```/``` page, it can set injectable page properly)