### PR TITLE
Feature/ftp fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Basic Concept
 Getting Started
 ---------------
 
-- You need Python3. We tested primarily with >=3.4
+- You need Python3. We tested primarily with **python 3.5**
 - This was tested with a recent Ubuntu based Linux.
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp
+yarl
 redis
 asyncio_redis
 uvloop

--- a/tanner/tests/test_rfi_emulation.py
+++ b/tanner/tests/test_rfi_emulation.py
@@ -34,3 +34,8 @@ class TestRfiEmulator(unittest.TestCase):
         data = "test data"
         with self.assertRaises(aiohttp.errors.ClientOSError):
             yield from self.handler.get_rfi_result(data)
+
+    def test_invalid_scheme(self):
+        path = 'file=file://mirror.yandex.ru/archlinux/foobar'
+        data = asyncio.get_event_loop().run_until_complete(self.handler.download_file(path))
+        self.assertIsNone(data)


### PR DESCRIPTION
#86 

Standard ftplib library now is used to retrieve ftp files. It solves the problem with downloading ftp.