### PR TITLE
Fix an error when LFI isn't properly detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Basic Concept
 Getting Started
 ---------------
 
-- You need Python3. We tested primarily with >=3.4
+- You need Python3. We tested primarily with **python 3.5**
 - This was tested with a recent Ubuntu based Linux.
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp
+yarl
 redis
 asyncio_redis
 uvloop

--- a/tanner/emulators/lfi.py
+++ b/tanner/emulators/lfi.py
@@ -31,7 +31,10 @@ class LfiEmulator:
 
     @asyncio.coroutine
     def get_file_path(self, path):
-        file_path = re.match(patterns.LFI_FILEPATH, path).group(1)
+        try:
+            file_path = re.match(patterns.LFI_FILEPATH, path).group(1)
+        except Exception as e:
+            file_path = path
         file_path = os.path.normpath(os.path.join('/', file_path))
         return file_path
 

--- a/tanner/emulators/rfi.py
+++ b/tanner/emulators/rfi.py
@@ -3,15 +3,18 @@ import hashlib
 import logging
 import os
 import re
+import time
+import ftplib
+from concurrent.futures import ThreadPoolExecutor
 
 import aiohttp
-
+import yarl
 from tanner.utils import patterns
 
 
 class RfiEmulator:
     def __init__(self, root_dir):
-        self.script_dir = os.path.join(root_dir,'files')
+        self.script_dir = os.path.join(root_dir, 'files')
         self.logger = logging.getLogger('tanner.rfi_emulator.RfiEmulator')
 
     @asyncio.coroutine
@@ -22,25 +25,50 @@ class RfiEmulator:
         if url is None:
             return None
         url = url.group(1)
+        url = yarl.URL(url)
 
         if not os.path.exists(self.script_dir):
             os.makedirs(self.script_dir)
 
-        if not (url.startswith("http") or url.startswith("ftp")):
-            return None
-        try:
-            with aiohttp.ClientSession() as client:
-                resp = yield from client.get(url)
-                data = yield from resp.text()
-        except aiohttp.ClientError as client_error:
-            self.logger.error('Error during downloading the rfi script %s', client_error)
+        if url.scheme == "ftp":
+            pool = ThreadPoolExecutor()
+            loop = asyncio.get_event_loop()
+            ftp_future = loop.run_in_executor(pool, self.download_file_ftp, url)
+            file_name = yield from ftp_future
+
         else:
-            yield from resp.release()
-            yield from client.close()
-            file_name = hashlib.md5(data.encode('utf-8')).hexdigest()
-            with open(os.path.join(self.script_dir,file_name), 'bw') as rfile:
-                rfile.write(data.encode('utf-8'))
+            try:
+                with aiohttp.ClientSession() as client:
+                    resp = yield from client.get(url)
+                    data = yield from resp.text()
+            except aiohttp.ClientError as client_error:
+                self.logger.error('Error during downloading the rfi script %s', client_error)
+            else:
+                yield from resp.release()
+                yield from client.close()
+                tmp_filename = url.name + str(time.time())
+                file_name = hashlib.md5(tmp_filename.encode('utf-8')).hexdigest()
+                with open(os.path.join(self.script_dir, file_name), 'bw') as rfile:
+                    rfile.write(data.encode('utf-8'))
         return file_name
+
+    def download_file_ftp(self, url):
+        host = url.host
+        ftp_path = url.path.rsplit('/', 1)[0][1:]
+        name = url.name
+        try:
+            ftp = ftplib.FTP(host)
+            ftp.login()
+            ftp.cwd(ftp_path)
+            tmp_filename = name + str(time.time())
+            file_name = hashlib.md5(tmp_filename.encode('utf-8')).hexdigest()
+            with open(file_name, 'wb') as ftp_script:
+                ftp.retrbinary('RETR %s' % name, ftp_script.write)
+        except ftplib.all_errors as ftp_errors:
+            self.logger.error("Problem with ftp download %s", ftp_errors)
+            return None
+        else:
+            return file_name
 
     @asyncio.coroutine
     def get_rfi_result(self, path):
@@ -49,7 +77,7 @@ class RfiEmulator:
         file_name = yield from self.download_file(path)
         if file_name is None:
             return rfi_result
-        with open(os.path.join(self.script_dir,file_name),'br') as script:
+        with open(os.path.join(self.script_dir, file_name), 'br') as script:
             script_data = script.read()
         try:
             with aiohttp.ClientSession() as session:

--- a/tanner/tests/test_rfi_emulation.py
+++ b/tanner/tests/test_rfi_emulation.py
@@ -34,3 +34,8 @@ class TestRfiEmulator(unittest.TestCase):
         data = "test data"
         with self.assertRaises(aiohttp.errors.ClientOSError):
             yield from self.handler.get_rfi_result(data)
+
+    def test_invalid_scheme(self):
+        path = 'file=file://mirror.yandex.ru/archlinux/foobar'
+        data = asyncio.get_event_loop().run_until_complete(self.handler.download_file(path))
+        self.assertIsNone(data)


### PR DESCRIPTION
The regex will somethimes match on LFI_ATTACK but not on LFI_FILEPATH.

This causes an exception due to ```file_path = re.match(patterns.LFI_FILEPATH, path).group(1)``` being ```None```


```
2016-12-05 15:46 INFO:tanner.server.HttpRequestHandler:handle_event: Requested path /etc/passwd
2016-12-05 15:46 ERROR:tanner.server.HttpRequestHandler:log_exception: Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/aiohttp/server.py", line 265, in start
    yield from self.handle_request(message, payload)
  File "/usr/local/lib/python3.5/dist-packages/Tanner-0.1.0-py3.5.egg/tanner/server.py", line 75, in handle_request
    response_msg = yield from self.handle_event(data, self.redis_client)
  File "/usr/local/lib/python3.5/dist-packages/Tanner-0.1.0-py3.5.egg/tanner/server.py", line 56, in handle_event
    detection = yield from self.base_handler.handle(data, session, path)
  File "/usr/local/lib/python3.5/dist-packages/Tanner-0.1.0-py3.5.egg/tanner/emulators/base.py", line 74, in handle
    detection = yield from self.emulate(data, session, path)
  File "/usr/local/lib/python3.5/dist-packages/Tanner-0.1.0-py3.5.egg/tanner/emulators/base.py", line 68, in emulate
    emulation_result = yield from emulator.handle(path, session)
  File "/usr/local/lib/python3.5/dist-packages/Tanner-0.1.0-py3.5.egg/tanner/emulators/lfi.py", line 60, in handle
    file_path = yield from self.get_file_path(path)
  File "/usr/lib/python3.5/asyncio/coroutines.py", line 206, in coro
    res = func(*args, **kw)
  File "/usr/local/lib/python3.5/dist-packages/Tanner-0.1.0-py3.5.egg/tanner/emulators/lfi.py", line 34, in get_file_path
    file_path = re.match(patterns.LFI_FILEPATH, path).group(1)
AttributeError: 'NoneType' object has no attribute 'group'

```