### PR TITLE
Fix an error when LFI isn't properly detected

### DIFF
--- a/tanner/emulators/lfi.py
+++ b/tanner/emulators/lfi.py
@@ -31,7 +31,10 @@ class LfiEmulator:
 
     @asyncio.coroutine
     def get_file_path(self, path):
-        file_path = re.match(patterns.LFI_FILEPATH, path).group(1)
+        try:
+            file_path = re.match(patterns.LFI_FILEPATH, path).group(1)
+        except Exception as e:
+            file_path = path
         file_path = os.path.normpath(os.path.join('/', file_path))
         return file_path
 


### PR DESCRIPTION
The regex will somethimes match on LFI_ATTACK but not on LFI_FILEPATH.

This causes an exception due to ```file_path = re.match(patterns.LFI_FILEPATH, path).group(1)``` being ```None```


```
2016-12-05 15:46 INFO:tanner.server.HttpRequestHandler:handle_event: Requested path /etc/passwd
2016-12-05 15:46 ERROR:tanner.server.HttpRequestHandler:log_exception: Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/aiohttp/server.py", line 265, in start
    yield from self.handle_request(message, payload)
  File "/usr/local/lib/python3.5/dist-packages/Tanner-0.1.0-py3.5.egg/tanner/server.py", line 75, in handle_request
    response_msg = yield from self.handle_event(data, self.redis_client)
  File "/usr/local/lib/python3.5/dist-packages/Tanner-0.1.0-py3.5.egg/tanner/server.py", line 56, in handle_event
    detection = yield from self.base_handler.handle(data, session, path)
  File "/usr/local/lib/python3.5/dist-packages/Tanner-0.1.0-py3.5.egg/tanner/emulators/base.py", line 74, in handle
    detection = yield from self.emulate(data, session, path)
  File "/usr/local/lib/python3.5/dist-packages/Tanner-0.1.0-py3.5.egg/tanner/emulators/base.py", line 68, in emulate
    emulation_result = yield from emulator.handle(path, session)
  File "/usr/local/lib/python3.5/dist-packages/Tanner-0.1.0-py3.5.egg/tanner/emulators/lfi.py", line 60, in handle
    file_path = yield from self.get_file_path(path)
  File "/usr/lib/python3.5/asyncio/coroutines.py", line 206, in coro
    res = func(*args, **kw)
  File "/usr/local/lib/python3.5/dist-packages/Tanner-0.1.0-py3.5.egg/tanner/emulators/lfi.py", line 34, in get_file_path
    file_path = re.match(patterns.LFI_FILEPATH, path).group(1)
AttributeError: 'NoneType' object has no attribute 'group'

```