### PR TITLE
require aiohttp<2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp
+aiohttp<2.0
 yarl
 redis
 asyncio_redis


### PR DESCRIPTION
Since aiohttp 2.0 release we can't use low-level server. So until we rewrite server, we should use aiohttp version <2.0