### PR TITLE
Support strings parameter attacks

### DIFF
--- a/tanner/emulators/sqli.py
+++ b/tanner/emulators/sqli.py
@@ -80,7 +80,7 @@ class SqliEmulator:
             if tables[0]['column']['type'] == 'INTEGER':
                 db_query = 'SELECT * from ' + tables[0]['table_name'] + ' WHERE ' + param + '=' + param_value + ';'
             else:
-                db_query = 'SELECT * from ' + tables[0]['table_name'] + ' WHERE ' + param + '= "' + param_value + '" ;'
+                db_query = 'SELECT * from ' + tables[0]['table_name'] + ' WHERE ' + param + '="' + param_value + '";'
 
         return db_query
 

--- a/tanner/emulators/sqli.py
+++ b/tanner/emulators/sqli.py
@@ -70,9 +70,17 @@ class SqliEmulator:
         db_query = None
         param = query[0][0]
         param_value = query[0][1].replace('\'', ' ')
-        tables = [k for k, v in self.query_map.items() if query[0][0] in v]
+        tables = []
+        for table, columns in self.query_map.items():
+            for column in columns: 
+                if query[0][0] == column['name']:
+                    tables.append(dict(table_name=table, column=column))
+
         if tables:
-            db_query = 'SELECT * from ' + tables[0] + ' WHERE ' + param + '=' + param_value + ';'
+            if tables[0]['column']['type'] == 'INTEGER':
+                db_query = 'SELECT * from ' + tables[0]['table_name'] + ' WHERE ' + param + '=' + param_value + ';'
+            else:
+                db_query = 'SELECT * from ' + tables[0]['table_name'] + ' WHERE ' + param + '= "' + param_value + '" ;'
 
         return db_query
 

--- a/tanner/tests/test_sqli.py
+++ b/tanner/tests/test_sqli.py
@@ -13,8 +13,11 @@ class SqliTest(unittest.TestCase):
         open('/tmp/db/test.db', 'a').close()
 
         query_map = {
-            'users': ['id', 'login', 'email', 'username', 'password', 'pass', 'log'],
-            'comments': ['comment']
+            'users': [{'name':'id', 'type':'INTEGER'}, {'name':'login', 'type':'text'},
+                      {'name':'email', 'type':'text'}, {'name':'username', 'type':'text'},
+                      {'name':'password', 'type':'text'}, {'name':'pass', 'type':'text'},
+                      {'name':'log', 'type':'text'}],
+            'comments': [{'name':'comment', 'type':'text'}]
         }
         self.handler = sqli.SqliEmulator('test.db', '/tmp/')
         self.handler.query_map = query_map
@@ -34,8 +37,8 @@ class SqliTest(unittest.TestCase):
         self.assertEqual(assert_result, result)
 
     def test_map_query_comments(self):
-        query = [('comment', 'some_comment\'UNION SELECT 1,2')]
-        assert_result = 'SELECT * from comments WHERE comment=some_comment UNION SELECT 1,2;'
+        query = [('comment', 'some_comment" UNION SELECT 1,2 AND "1"="1')]
+        assert_result = 'SELECT * from comments WHERE comment="some_comment" UNION SELECT 1,2 AND "1"="1";'
         loop = asyncio.get_event_loop()
         result = loop.run_until_complete(self.handler.map_query(query))
         self.assertEqual(assert_result, result)

--- a/tanner/utils/db_helper.py
+++ b/tanner/utils/db_helper.py
@@ -128,7 +128,7 @@ class DBHelper:
                 columns = []
                 try:
                     for row in cursor.execute(query):
-                        columns.append(row[1])
+                        columns.append(dict(name=row[1], type=row[2]))
                     query_map[table] = columns
                 except sqlite3.OperationalError as sqlite_error:
                     self.logger.error('Error during query map creation: %s', sqlite_error)


### PR DESCRIPTION
Current SQLI emulator doesn't support string parameter. If we pass a valid attack like `?username=something" UNION SELECT 1,2,3,4 --`, then it produces an unexpected error.
Though it should be a successful attack.
With this fix, strings parameter attacks are also supported. I have put different queries for string and integer attacks.