### PR TITLE
Improve base emulator architecture

### DIFF
--- a/tanner/emulators/base.py
+++ b/tanner/emulators/base.py
@@ -6,7 +6,6 @@ import yarl
 from tanner.emulators import lfi, rfi, sqli, xss, cmd_exec
 from tanner.utils import patterns
 
-
 class BaseHandler:
     def __init__(self, base_dir, db_name, loop=None):
         self.emulators = {
@@ -22,14 +21,6 @@ class BaseHandler:
         path = path.replace('&&', '%26%26').replace(';', '%3B')
         get_data = yarl.URL(path).query
         return get_data
-        # get_data = {}
-        # query = yarl.URL(path).query_string
-        # params = query.split('&')
-        # for param in params:
-        #     if len(param.split('=')) == 2:
-        #         param_id, param_value = param.split('=')
-        #         get_data[param_id] = param_value
-        # return get_data
 
     async def get_emulation_result(self, session, data, target_emulators):
         detection = dict(name='unknown', order=0)
@@ -37,7 +28,6 @@ class BaseHandler:
         for param_id, param_value in data.items():
             for emulator in target_emulators:
                 possible_detection = self.emulators[emulator].scan(param_value)
-                print(emulator, possible_detection)
                 if possible_detection:
                     if detection['order'] < possible_detection['order']:
                         detection = possible_detection
@@ -50,15 +40,14 @@ class BaseHandler:
         return detection
 
     async def handle_post(self, session, data):
-        #post_emulators = ['rfi', 'lfi', 'xss', 'sqli', 'cmd_exec']
-        post_emulators = ['rfi', 'lfi', 'cmd_exec']
+        post_emulators = ['sqli', 'rfi', 'lfi', 'xss', 'cmd_exec']
         post_data = data['post_data']
 
         detection = await self.get_emulation_result(session, post_data, post_emulators)
         return detection
 
     async def handle_get(self, session, path):
-        get_emulators = ['sqli', 'rfi', 'lfi', 'cmd_exec']
+        get_emulators = ['sqli', 'rfi', 'lfi', 'xss', 'cmd_exec']
         
         get_data = self.extract_get_data(path)
         detection = dict(name='unknown', order=0)

--- a/tanner/emulators/base.py
+++ b/tanner/emulators/base.py
@@ -18,7 +18,9 @@ class BaseHandler:
 
     def extract_get_data(self, path):
         path = urllib.parse.unquote(path)
-        path = path.replace('&&', '%26%26').replace(';', '%3B')
+        encodings = [('&&', '%26%26'), (';', '%3B')] 
+        for value, encoded_value in encodings:
+            path = path.replace(value, encoded_value)
         get_data = yarl.URL(path).query
         return get_data
 

--- a/tanner/emulators/base.py
+++ b/tanner/emulators/base.py
@@ -15,6 +15,8 @@ class BaseHandler:
             'sqli': sqli.SqliEmulator(db_name, base_dir),
             'cmd_exec': cmd_exec.CmdExecEmulator()
         }
+        self.get_emulators = ['sqli', 'rfi', 'lfi', 'xss', 'cmd_exec']
+        self.post_emulators = ['sqli', 'rfi', 'lfi', 'xss', 'cmd_exec']
 
     def extract_get_data(self, path):
         path = urllib.parse.unquote(path)
@@ -44,15 +46,12 @@ class BaseHandler:
         return detection
 
     async def handle_post(self, session, data):
-        post_emulators = ['sqli', 'rfi', 'lfi', 'xss', 'cmd_exec']
         post_data = data['post_data']
 
-        detection = await self.get_emulation_result(session, post_data, post_emulators)
+        detection = await self.get_emulation_result(session, post_data, self.post_emulators)
         return detection
 
     async def handle_get(self, session, path):
-        get_emulators = ['sqli', 'rfi', 'lfi', 'xss', 'cmd_exec']
-        
         get_data = self.extract_get_data(path)
         detection = dict(name='unknown', order=0)
         # dummy for wp-content
@@ -61,7 +60,7 @@ class BaseHandler:
         if re.match(patterns.INDEX, path):
             detection = {'name': 'index', 'order': 1}
 
-        possible_detection = await self.get_emulation_result(session, get_data, get_emulators)
+        possible_detection = await self.get_emulation_result(session, get_data, self.get_emulators)
         if possible_detection and detection['order'] < possible_detection['order'] :
             detection = possible_detection
 

--- a/tanner/emulators/base.py
+++ b/tanner/emulators/base.py
@@ -8,13 +8,6 @@ from tanner.utils import patterns
 
 
 class BaseHandler:
-    # Reference patterns
-    patterns = {
-        patterns.RFI_ATTACK: dict(name='rfi', order=2),
-        patterns.LFI_ATTACK: dict(name='lfi', order=2),
-        patterns.XSS_ATTACK: dict(name='xss', order=3)
-    }
-
     def __init__(self, base_dir, db_name, loop=None):
         self.emulators = {
             'rfi': rfi.RfiEmulator(base_dir, loop),
@@ -24,25 +17,45 @@ class BaseHandler:
             'cmd_exec': cmd_exec.CmdExecEmulator()
         }
 
-    async def handle_post(self, session, data):
+    def extract_get_data(self, path):
+        get_data = {}
+        query = yarl.URL(path).query_string
+        params = query.split('&')
+        for param in params:
+            if len(param.split('=')) == 2:
+                param_id, param_value = param.split('=')
+                get_data[param_id] = param_value
+        return get_data
+
+    async def get_emulation_result(self, session, data, target_emulators):
         detection = dict(name='unknown', order=0)
-        xss_result = await self.emulators['xss'].handle(None, session, data)
-        if xss_result:
-            detection = {'name': 'xss', 'order': 2, 'payload': xss_result}
-        else:
-            sqli_data = self.emulators['sqli'].check_post_data(data)
-            if sqli_data:
-                sqli_result = await self.emulators['sqli'].handle(sqli_data, session, 1)
-                detection = {'name': 'sqli', 'order': 2, 'payload': sqli_result}
-            else:
-                cmd_exec_data = await self.emulators['cmd_exec'].check_post_data(data)
-                if cmd_exec_data:
-                    cmd_exec_results = await self.emulators['cmd_exec'].handle(cmd_exec_data[0][1], session)
-                    detection = {'name': 'cmd_exec', 'order': 3, 'payload': cmd_exec_results}
+
+        for param_id, param_value in data.items():
+            for emulator in target_emulators:
+                possible_detection = self.emulators[emulator].scan(param_value)
+                if possible_detection:
+                    if detection['order'] < possible_detection['order']:
+                        detection = possible_detection
+                        attack_value = param_value
+
+        if detection['name'] in self.emulators:
+            emulation_result = await self.emulators[detection['name']].handle(attack_value, session)
+            detection['payload'] = emulation_result
 
         return detection
 
+    async def handle_post(self, session, data):
+        post_emulators = ['rfi', 'lfi', 'xss', 'sqli', 'cmd_exec']
+        post_data = data['post_data']
+
+        detection = await self.get_emulation_result(session, post_data, post_emulators)
+        return detection
+
     async def handle_get(self, session, path):
+        get_emulators = ['rfi', 'lfi', 'xss', 'sqli', 'cmd_exec']
+        path = urllib.parse.unquote(path)
+        get_data = self.extract_get_data(path)
+
         detection = dict(name='unknown', order=0)
         # dummy for wp-content
         if re.match(patterns.WORD_PRESS_CONTENT, path):
@@ -50,30 +63,9 @@ class BaseHandler:
         if re.match(patterns.INDEX, path):
             detection = {'name': 'index', 'order': 1}
 
-        path = urllib.parse.unquote(path)
-        query = yarl.URL(path).query
-
-        for name, value in query.items():
-            for pattern, patter_details in self.patterns.items():
-                if pattern.match(value):
-                    if detection['order'] < patter_details['order']:
-                        detection = patter_details
-                        attack_value = value
-
-        if detection['order'] <= 1:
-            cmd_exec = await self.emulators['cmd_exec'].check_get_data(path)
-            if cmd_exec:
-                detection = {'name': 'cmd_exec', 'order': 3}
-                attack_value = cmd_exec[0][1]
-            else:
-                sqli = self.emulators['sqli'].check_get_data(path)
-                if sqli:
-                    detection = {'name': 'sqli', 'order': 2}
-                    attack_value = path
-
-        if detection['name'] in self.emulators:
-            emulation_result = await self.emulators[detection['name']].handle(attack_value, session)
-            detection['payload'] = emulation_result
+        possible_detection = await self.get_emulation_result(session, get_data, get_emulators)
+        if possible_detection and detection['order'] < possible_detection['order'] :
+            detection = possible_detection
 
         return detection
 

--- a/tanner/emulators/base.py
+++ b/tanner/emulators/base.py
@@ -26,17 +26,19 @@ class BaseHandler:
 
     async def get_emulation_result(self, session, data, target_emulators):
         detection = dict(name='unknown', order=0)
-
+        attack_params = {}
         for param_id, param_value in data.items():
             for emulator in target_emulators:
                 possible_detection = self.emulators[emulator].scan(param_value)
                 if possible_detection:
                     if detection['order'] < possible_detection['order']:
                         detection = possible_detection
-                        attack_param = dict(id= param_id, value= param_value)
-
+                    if emulator not in attack_params:
+                        attack_params[emulator] = []
+                    attack_params[emulator].append(dict(id= param_id, value= param_value))
+                    
         if detection['name'] in self.emulators:
-            emulation_result = await self.emulators[detection['name']].handle(attack_param, session)
+            emulation_result = await self.emulators[detection['name']].handle(attack_params[detection['name']], session)
             detection['payload'] = emulation_result
 
         return detection

--- a/tanner/emulators/base.py
+++ b/tanner/emulators/base.py
@@ -19,6 +19,11 @@ class BaseHandler:
         self.post_emulators = ['sqli', 'rfi', 'lfi', 'xss', 'cmd_exec']
 
     def extract_get_data(self, path):
+        """
+        Return all the GET parameter
+        :param path: The URL path from which GET parameters are to be extracted
+        :return: A MultiDictProxy object containg name and value of parameters
+        """
         path = urllib.parse.unquote(path)
         encodings = [('&&', '%26%26'), (';', '%3B')] 
         for value, encoded_value in encodings:
@@ -27,6 +32,13 @@ class BaseHandler:
         return get_data
 
     async def get_emulation_result(self, session, data, target_emulators):
+        """
+        Return emulation result for the vulnerabilty of highest order
+        :param session: Current active session
+        :param data: Data to be checked
+        :param target_emulator: Emulators against which data is to be checked
+        :return: A dict object containing name, order and paylod to be injected for vulnerability  
+        """
         detection = dict(name='unknown', order=0)
         attack_params = {}
         for param_id, param_value in data.items():

--- a/tanner/emulators/base.py
+++ b/tanner/emulators/base.py
@@ -21,7 +21,7 @@ class BaseHandler:
     def extract_get_data(self, path):
         """
         Return all the GET parameter
-        :param path: The URL path from which GET parameters are to be extracted
+        :param path (str): The URL path from which GET parameters are to be extracted
         :return: A MultiDictProxy object containg name and value of parameters
         """
         path = urllib.parse.unquote(path)
@@ -34,9 +34,9 @@ class BaseHandler:
     async def get_emulation_result(self, session, data, target_emulators):
         """
         Return emulation result for the vulnerabilty of highest order
-        :param session: Current active session
-        :param data: Data to be checked
-        :param target_emulator: Emulators against which data is to be checked
+        :param session (Session object): Current active session
+        :param data (MultiDictProxy object): Data to be checked
+        :param target_emulator (list): Emulators against which data is to be checked
         :return: A dict object containing name, order and paylod to be injected for vulnerability  
         """
         detection = dict(name='unknown', order=0)

--- a/tanner/emulators/cmd_exec.py
+++ b/tanner/emulators/cmd_exec.py
@@ -69,23 +69,11 @@ class CmdExecEmulator:
         except docker.errors.APIError as server_error:
             self.logger.error('Error while removing container %s', server_error)
 
-    async def check_post_data(self, data):
-        cmd_data = []
-        for (param_id, param_value) in data['post_data'].items():
-            if patterns.CMD_ATTACK.match(param_value):
-                cmd_data.append((param_id, param_value))
-        return cmd_data
-        
-    async def check_get_data(self, path):
-        cmd_data = []
-        query = yarl.URL(path).query_string
-        params = query.split('&')
-        for param in params:
-            if len(param.split('=')) == 2:
-                param_id, param_value = param.split('=')
-                if patterns.CMD_ATTACK.match(param_value):
-                    cmd_data.append((param_id, param_value))
-        return cmd_data
+    def scan(self, value):
+        detection = None
+        if patterns.CMD_ATTACK.match(value):
+            detection = dict(name= 'cmd_exec', order= 3)
+        return detection
 
     async def handle(self, value, session= None):
         container = await self.create_attacker_env(session)

--- a/tanner/emulators/cmd_exec.py
+++ b/tanner/emulators/cmd_exec.py
@@ -75,7 +75,7 @@ class CmdExecEmulator:
             detection = dict(name= 'cmd_exec', order= 3)
         return detection
 
-    async def handle(self, value, session= None):
+    async def handle(self, attack_param, session= None):
         container = await self.create_attacker_env(session)
-        result = await self.get_cmd_exec_results(container, value)
+        result = await self.get_cmd_exec_results(container, attack_param['value'])
         return result

--- a/tanner/emulators/cmd_exec.py
+++ b/tanner/emulators/cmd_exec.py
@@ -75,7 +75,7 @@ class CmdExecEmulator:
             detection = dict(name= 'cmd_exec', order= 3)
         return detection
 
-    async def handle(self, attack_param, session= None):
+    async def handle(self, attack_params, session= None):
         container = await self.create_attacker_env(session)
-        result = await self.get_cmd_exec_results(container, attack_param['value'])
+        result = await self.get_cmd_exec_results(container, attack_params[0]['value'])
         return result

--- a/tanner/emulators/lfi.py
+++ b/tanner/emulators/lfi.py
@@ -50,6 +50,11 @@ class LfiEmulator:
                     with open(filename, 'w') as vd:
                         vd.write(value)
 
+    def scan(self, value):
+        detection = None
+        if patterns.LFI_ATTACK.match(value):
+            detection = dict(name= 'lfi', order= 2)
+        return detection
 
     async def handle(self, path, session=None):
         if not self.whitelist:

--- a/tanner/emulators/lfi.py
+++ b/tanner/emulators/lfi.py
@@ -56,9 +56,9 @@ class LfiEmulator:
             detection = dict(name= 'lfi', order= 2)
         return detection
 
-    async def handle(self, path, session=None):
+    async def handle(self, attack_value, session=None):
         if not self.whitelist:
             self.available_files()
-        file_path = self.get_file_path(path)
+        file_path = self.get_file_path(attack_value['value'])
         result = self.get_lfi_result(file_path)
         return result

--- a/tanner/emulators/lfi.py
+++ b/tanner/emulators/lfi.py
@@ -56,9 +56,9 @@ class LfiEmulator:
             detection = dict(name= 'lfi', order= 2)
         return detection
 
-    async def handle(self, attack_value, session=None):
+    async def handle(self, attack_params, session=None):
         if not self.whitelist:
             self.available_files()
-        file_path = self.get_file_path(attack_value['value'])
+        file_path = self.get_file_path(attack_params[0]['value'])
         result = self.get_lfi_result(file_path)
         return result

--- a/tanner/emulators/rfi.py
+++ b/tanner/emulators/rfi.py
@@ -90,6 +90,12 @@ class RfiEmulator:
             await session.close()
         return rfi_result
 
+    def scan(self, value):
+        detection = None
+        if patterns.RFI_ATTACK.match(value):
+            detection = dict(name= 'rfi', order= 2)
+        return detection
+
     async def handle(self, path, session=None):
         result = await self.get_rfi_result(path)
         if not result or 'stdout' not in result:

--- a/tanner/emulators/rfi.py
+++ b/tanner/emulators/rfi.py
@@ -96,8 +96,8 @@ class RfiEmulator:
             detection = dict(name= 'rfi', order= 2)
         return detection
 
-    async def handle(self, attack_value, session=None):
-        result = await self.get_rfi_result(attack_value['value'])
+    async def handle(self, attack_params, session=None):
+        result = await self.get_rfi_result(attack_params[0]['value'])
         if not result or 'stdout' not in result:
             return ''
         else:

--- a/tanner/emulators/rfi.py
+++ b/tanner/emulators/rfi.py
@@ -96,8 +96,8 @@ class RfiEmulator:
             detection = dict(name= 'rfi', order= 2)
         return detection
 
-    async def handle(self, path, session=None):
-        result = await self.get_rfi_result(path)
+    async def handle(self, attack_value, session=None):
+        result = await self.get_rfi_result(attack_value['value'])
         if not result or 'stdout' not in result:
             return ''
         else:

--- a/tanner/emulators/sqli.py
+++ b/tanner/emulators/sqli.py
@@ -56,9 +56,9 @@ class SqliEmulator:
             result = dict(value=execute_result, page='/index.html')
         return result
 
-    async def handle(self, attack_value, session):
+    async def handle(self, attack_params, session):
         if self.query_map is None:
             self.query_map = await self.sqli_emulator.setup_db(self.query_map)
         attacker_db = await self.sqli_emulator.create_attacker_db(session)
-        result = await self.get_sqli_result(attack_value, attacker_db)
+        result = await self.get_sqli_result(attack_params[0], attacker_db)
         return result

--- a/tanner/emulators/sqli.py
+++ b/tanner/emulators/sqli.py
@@ -16,41 +16,23 @@ class SqliEmulator:
 
         self.query_map = None
 
-    @staticmethod
-    def check_sqli(path):
-        payload = bytes(path, 'utf-8')
+    def scan(self, value):
+        print(value)
+        detection = None
+        payload = bytes(value, 'utf-8')
         sqli = pylibinjection.detect_sqli(payload)
-        return int(sqli['sqli'])
+        if int(sqli['sqli']):
+            detection = dict(name= 'sqli', order= 2)
+        return detection
 
-    def check_post_data(self, data):
-        sqli_data = []
-        for (param, value) in data['post_data'].items():
-            sqli = self.check_sqli(value)
-            if sqli:
-                sqli_data.append((param, value))
-        return sqli_data
-
-    def check_get_data(self, path):
-        request_query = urllib.parse.urlparse(path).query
-        parsed_queries = urllib.parse.parse_qsl(request_query)
-        for query in parsed_queries:
-            sqli = self.check_sqli(query[1])
-            return sqli
-
-    @staticmethod
-    def prepare_get_query(path):
-        query = urllib.parse.urlparse(path).query
-        parsed_query = urllib.parse.parse_qsl(query)
-        return parsed_query
-
-    def map_query(self, query):
+    def map_query(self, attack_value):
         db_query = None
-        param = query[0][0]
-        param_value = query[0][1].replace('\'', ' ')
+        param = attack_value['id']
+        param_value = attack_value['value'].replace('\'', ' ')
         tables = []
         for table, columns in self.query_map.items():
             for column in columns: 
-                if query[0][0] == column['name']:
+                if param == column['name']:
                     tables.append(dict(table_name=table, column=column))
 
         if tables:
@@ -61,8 +43,8 @@ class SqliEmulator:
 
         return db_query
 
-    async def get_sqli_result(self, query, attacker_db):
-        db_query = self.map_query(query)
+    async def get_sqli_result(self, attack_value, attacker_db):
+        db_query = self.map_query(attack_value)
         if db_query is None:
             result = 'You have an error in your SQL syntax; check the manual\
                         that corresponds to your MySQL server version for the\
@@ -74,11 +56,9 @@ class SqliEmulator:
             result = dict(value=execute_result, page='/index.html')
         return result
 
-    async def handle(self, path, session, post_request=0):
+    async def handle(self, attack_value, session):
         if self.query_map is None:
             self.query_map = await self.sqli_emulator.setup_db(self.query_map)
-        if not post_request:
-            path = self.prepare_get_query(path)
         attacker_db = await self.sqli_emulator.create_attacker_db(session)
-        result = await self.get_sqli_result(path, attacker_db)
+        result = await self.get_sqli_result(attack_value, attacker_db)
         return result

--- a/tanner/emulators/sqli.py
+++ b/tanner/emulators/sqli.py
@@ -48,7 +48,7 @@ class SqliEmulator:
         if db_query is None:
             result = 'You have an error in your SQL syntax; check the manual\
                         that corresponds to your MySQL server version for the\
-                        right syntax to use near {} at line 1'.format(query[0][0])
+                        right syntax to use near {} at line 1'.format(attack_value['id'])
         else:
             execute_result = await self.sqli_emulator.execute_query(db_query, attacker_db)
             if isinstance(execute_result, list):

--- a/tanner/emulators/xss.py
+++ b/tanner/emulators/xss.py
@@ -13,16 +13,18 @@ class XssEmulator:
             detection = dict(name= 'xss', order= 3)
         return detection
 
-    def get_xss_result(self, session, val):
+    def get_xss_result(self, session, attack_params):
         result = None
         injectable_page = None
+        value = ''
         if session:
             injectable_page = self.set_xss_page(session)
         if injectable_page is None:
             injectable_page = '/index.html'
-        if val:
-            result = dict(value=val,
-                          page=injectable_page)
+        for param in attack_params:
+            value += param['value'] if not value else '\n' + param['value']
+        result = dict(value=value,
+                      page=injectable_page)
         return result
 
     @staticmethod
@@ -33,7 +35,7 @@ class XssEmulator:
                 injectable_page = page['path']
         return injectable_page
 
-    async def handle(self, attack_value, session):
+    async def handle(self, attack_params, session):
         xss_result = None
-        xss_result = self.get_xss_result(session, attack_value['value'])
+        xss_result = self.get_xss_result(session, attack_params)
         return xss_result

--- a/tanner/emulators/xss.py
+++ b/tanner/emulators/xss.py
@@ -10,7 +10,7 @@ class XssEmulator:
     def scan(self, value):
         detection = None
         if patterns.XSS_ATTACK.match(value):
-            detection = dict(name= 'cmd_exec', order= 3)
+            detection = dict(name= 'xss', order= 3)
         return detection
 
     def get_xss_result(self, session, val):

--- a/tanner/emulators/xss.py
+++ b/tanner/emulators/xss.py
@@ -6,16 +6,12 @@ from tanner.utils import patterns
 
 
 class XssEmulator:
-    @staticmethod
-    def extract_xss_data(data):
-        value = ''
-        if 'post_data' in data:
-            for field, val in data['post_data'].items():
-                val = urllib.parse.unquote(val)
-                xss = re.match(patterns.HTML_TAGS, val)
-                if xss:
-                    value += val if not value else '\n' + val
-        return value
+    
+    def scan(self, value):
+        detection = None
+        if patterns.XSS_ATTACK.match(value):
+            detection = dict(name= 'cmd_exec', order= 3)
+        return detection
 
     def get_xss_result(self, session, val):
         result = None
@@ -37,9 +33,7 @@ class XssEmulator:
                 injectable_page = page['path']
         return injectable_page
 
-    async def handle(self, value, session, raw_data=None):
+    async def handle(self, attack_value, session):
         xss_result = None
-        if not value:
-            value = self.extract_xss_data(raw_data)
-        xss_result = self.get_xss_result(session, value)
+        xss_result = self.get_xss_result(session, attack_value['value'])
         return xss_result

--- a/tanner/tests/test_base.py
+++ b/tanner/tests/test_base.py
@@ -15,53 +15,66 @@ class TestBase(unittest.TestCase):
         with mock.patch('tanner.emulators.lfi.LfiEmulator', mock.Mock(), create=True):
             self.handler = base.BaseHandler('/tmp/', 'test.db', self.loop)
 
-    def test_handle_get_sqli(self):
+        def mock_lfi_scan(value):
+            return dict(name= 'lfi', order= 0)
+
+        self.handler.emulators['lfi'].scan = mock_lfi_scan
+
+    def test_handle_sqli(self):
         path = '/index.html?id=1 UNION SELECT 1'
 
-        async def mock_sqli_check_get_data(path):
-            return 1
-
-        async def mock_sqli_handle(path, session, post_request=0):
+        async def mock_sqli_handle(path, session):
             return 'sqli_test_payload'
 
+        def mock_sqli_scan(value):
+            return dict(name= 'sqli', order= 2)
+
         self.handler.emulators['sqli'] = mock.Mock()
-        self.handler.emulators['sqli'].check_get_data = mock_sqli_check_get_data
         self.handler.emulators['sqli'].handle = mock_sqli_handle
+        self.handler.emulators['sqli'].scan = mock_sqli_scan
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
 
         assert_detection = {'name': 'sqli', 'order': 2, 'payload': 'sqli_test_payload'}
         self.assertDictEqual(detection, assert_detection)
 
-    def test_handle_get_xss(self):
+    def test_handle_xss(self):
         path = '/index.html?id=<script>alert(1);</script>'
 
-        async def mock_xss_handle(path, session, post_request=0):
+        async def mock_xss_handle(path, session):
             return 'xss_test_payload'
+
+        def mock_xss_scan(value):
+            return dict(name= 'xss', order= 3)
 
         self.handler.emulators['xss'] = mock.Mock()
         self.handler.emulators['xss'].handle = mock_xss_handle
+        self.handler.emulators['xss'].scan = mock_xss_scan
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
 
         assert_detection = {'name': 'xss', 'order': 3, 'payload': 'xss_test_payload'}
         self.assertDictEqual(detection, assert_detection)
 
-    def test_handle_get_lfi(self):
+    def test_handle_lfi(self):
         path = '/index.html?file=/etc/passwd'
 
-        async def mock_lfi_handle(path, session, post_request=0):
+        async def mock_lfi_handle(attack_value, session):
             return 'lfi_test_payload'
+        
+        def mock_lfi_scan(value):
+            return dict(name= 'lfi', order= 2)
 
         self.handler.emulators['lfi'] = mock.Mock()
         self.handler.emulators['lfi'].handle = mock_lfi_handle
+        self.handler.emulators['lfi'].scan = mock_lfi_scan
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
 
         assert_detection = {'name': 'lfi', 'order': 2, 'payload': 'lfi_test_payload'}
         self.assertDictEqual(detection, assert_detection)
 
-    def test_handle_get_index(self):
+    def test_handle_index(self):
         path = '/index.html'
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
@@ -69,7 +82,7 @@ class TestBase(unittest.TestCase):
         assert_detection = detection = {'name': 'index', 'order': 1}
         self.assertDictEqual(detection, assert_detection)
 
-    def test_handle_get_wp_content(self):
+    def test_handle_wp_content(self):
         path = '/wp-content'
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
@@ -77,38 +90,20 @@ class TestBase(unittest.TestCase):
         assert_detection = detection = {'name': 'wp-content', 'order': 1}
         self.assertDictEqual(detection, assert_detection)
 
-    def test_handle_get_rfi(self):
+    def test_handle_rfi(self):
         path = '/index.html?file=http://attack.php'
 
-        async def mock_rfi_handle(path, session, post_request=0):
+        async def mock_rfi_handle(path, session):
             return 'rfi_test_payload'
+
+        def mock_rfi_scan(value):
+            return dict(name= 'rfi', order= 2)
 
         self.handler.emulators['rfi'] = mock.Mock()
         self.handler.emulators['rfi'].handle = mock_rfi_handle
+        self.handler.emulators['rfi'].scan = mock_rfi_scan
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
 
         assert_detection = {'name': 'rfi', 'order': 2, 'payload': 'rfi_test_payload'}
-        self.assertDictEqual(detection, assert_detection)
-
-    def test_handle_post_xss(self):
-        async def mock_xss_handle(value, session, raw_data=None):
-            return 'xss_test_payload'
-
-        self.handler.emulators['xss'] = mock.Mock()
-        self.handler.emulators['xss'].handle = mock_xss_handle
-
-        async def mock_sqli_check_post_data(data):
-            return 1
-
-        async def mock_sqli_handle(path, session, post_request=0):
-            return None
-
-        self.handler.emulators['sqli'] = mock.Mock()
-        self.handler.emulators['sqli'].check_post_data = mock_sqli_check_post_data
-        self.handler.emulators['sqli'].handle = mock_sqli_handle
-
-        detection = self.loop.run_until_complete(self.handler.handle_post(self.session, self.data))
-
-        assert_detection = {'name': 'xss', 'order': 2, 'payload': 'xss_test_payload'}
         self.assertDictEqual(detection, assert_detection)

--- a/tanner/tests/test_lfi_emulator.py
+++ b/tanner/tests/test_lfi_emulator.py
@@ -15,19 +15,16 @@ class TestLfiEmulator(unittest.TestCase):
         self.handler = lfi.LfiEmulator('/tmp/')
 
     def test_handle_abspath_lfi(self):
-        path = '/?foo=/etc/passwd'
-        query = yarl.URL(path).query
-        result = self.loop.run_until_complete(self.handler.handle(query['foo']))
+        attack_params = [dict(id= 'foo', value= '/etc/passwd')]
+        result = self.loop.run_until_complete(self.handler.handle(attack_params))
         self.assertIn('root:x:0:0:root:/root:/bin/bash', result)
 
     def test_handle_relative_path_lfi(self):
-        path = '/?foo=../../../../../etc/passwd'
-        query = yarl.URL(path).query
-        result = self.loop.run_until_complete(self.handler.handle(query['foo']))
+        attack_params = [dict(id= 'foo', value= '../../../../../etc/passwd')]
+        result = self.loop.run_until_complete(self.handler.handle(attack_params))
         self.assertIn('root:x:0:0:root:/root:/bin/bash', result)
 
     def test_handle_missing_lfi(self):
-        path = '/?foo=../../../../../etc/bar'
-        query = yarl.URL(path).query
-        result = self.loop.run_until_complete(self.handler.handle(query['foo']))
+        attack_params = [dict(id= 'foo', value= '../../../../../etc/bar')]
+        result = self.loop.run_until_complete(self.handler.handle(attack_params))
         self.assertIsNone(result)

--- a/tanner/tests/test_sqli.py
+++ b/tanner/tests/test_sqli.py
@@ -22,24 +22,24 @@ class SqliTest(unittest.TestCase):
         self.handler.query_map = query_map
 
     def test_map_query_id(self):
-        query = [('id', '1\'UNION SELECT 1,2,3,4')]
+        attack_value = dict(id= 'id', value= '1\'UNION SELECT 1,2,3,4')
         assert_result = 'SELECT * from users WHERE id=1 UNION SELECT 1,2,3,4;'
-        result = self.handler.map_query(query)
+        result = self.handler.map_query(attack_value)
         self.assertEqual(assert_result, result)
 
     def test_map_query_comments(self):
-        query = [('comment', 'some_comment" UNION SELECT 1,2 AND "1"="1')]
+        attack_value = dict(id= 'comment', value= 'some_comment" UNION SELECT 1,2 AND "1"="1')
         assert_result = 'SELECT * from comments WHERE comment="some_comment" UNION SELECT 1,2 AND "1"="1";'
-        result = self.handler.map_query(query)
+        result = self.handler.map_query(attack_value)
         self.assertEqual(assert_result, result)
 
     def test_map_query_error(self):
-        query = [('foo', 'bar\'UNION SELECT 1,2')]
-        result = self.handler.map_query(query)
+        attack_value = dict(id= 'foo', value= 'bar\'UNION SELECT 1,2')
+        result = self.handler.map_query(attack_value)
         self.assertIsNone(result)
 
     def test_get_sqli_result(self):
-        query = [('id', '1 UNION SELECT 1,2,3,4')]
+        attack_value = dict(id= 'id', value= '1 UNION SELECT 1,2,3,4')
 
         async def mock_execute_query(query, db_name):
             return [[1, 'name', 'email@mail.com', 'password'], [1, '2', '3', '4']]
@@ -50,13 +50,13 @@ class SqliTest(unittest.TestCase):
         assert_result = dict(value="[1, 'name', 'email@mail.com', 'password'] [1, '2', '3', '4']",
                              page='/index.html'
                              )
-        result = self.loop.run_until_complete(self.handler.get_sqli_result(query, 'foo.db'))
+        result = self.loop.run_until_complete(self.handler.get_sqli_result(attack_value, 'foo.db'))
         self.assertEqual(assert_result, result)
 
     def test_get_sqli_result_error(self):
-        query = [('foo', 'bar\'UNION SELECT 1,2')]
+        attack_value = dict(id= 'foo', value= 'bar\'UNION SELECT 1,2')
         assert_result = 'You have an error in your SQL syntax; check the manual\
                         that corresponds to your MySQL server version for the\
                         right syntax to use near foo at line 1'
-        result = self.loop.run_until_complete(self.handler.get_sqli_result(query, 'foo.db'))
+        result = self.loop.run_until_complete(self.handler.get_sqli_result(attack_value, 'foo.db'))
         self.assertEqual(assert_result, result)


### PR DESCRIPTION
With this, a new emulator can be coordinated with `base` emulator by simply adding its name to `get_emulators` or `post_emulators`. The emulator has to provide a `scan` method and this new `base emulator` will provide them all the `GET` or `POST` params vulnerable to that specific vulnerability.
Fix #148 