### PR TITLE
Fix rfi

### DIFF
--- a/tanner/emulators/base.py
+++ b/tanner/emulators/base.py
@@ -17,6 +17,7 @@ class BaseHandler:
         }
         self.get_emulators = ['sqli', 'rfi', 'lfi', 'xss', 'cmd_exec']
         self.post_emulators = ['sqli', 'rfi', 'lfi', 'xss', 'cmd_exec']
+        self.cookie_emulators = ['sqli']
 
     def extract_get_data(self, path):
         """
@@ -43,7 +44,7 @@ class BaseHandler:
         attack_params = {}
         for param_id, param_value in data.items():
             for emulator in target_emulators:
-                possible_detection = self.emulators[emulator].scan(param_value)
+                possible_detection = self.emulators[emulator].scan(param_value) if param_value else None
                 if possible_detection:
                     if detection['order'] < possible_detection['order']:
                         detection = possible_detection
@@ -63,7 +64,14 @@ class BaseHandler:
         detection = await self.get_emulation_result(session, post_data, self.post_emulators)
         return detection
 
-    async def handle_get(self, session, path):
+    async def handle_cookies(self, session, data):
+        cookies = data['cookies']
+
+        detection = await self.get_emulation_result(session, cookies, self.cookie_emulators)
+        return detection
+
+    async def handle_get(self, session, data):
+        path = data['path']
         get_data = self.extract_get_data(path)
         detection = dict(name='unknown', order=0)
         # dummy for wp-content
@@ -71,21 +79,25 @@ class BaseHandler:
             detection = {'name': 'wp-content', 'order': 1}
         if re.match(patterns.INDEX, path):
             detection = {'name': 'index', 'order': 1}
-
-        possible_detection = await self.get_emulation_result(session, get_data, self.get_emulators)
-        if possible_detection and detection['order'] < possible_detection['order'] :
-            detection = possible_detection
+        # check attacks against get parameters
+        possible_get_detection = await self.get_emulation_result(session, get_data, self.get_emulators)
+        if possible_get_detection and detection['order'] < possible_get_detection['order'] :
+            detection = possible_get_detection
+        # check attacks against cookie values
+        possible_cookie_detection = await self.handle_cookies(session, data)
+        if possible_cookie_detection and detection['order'] < possible_cookie_detection['order'] :
+            detection = possible_cookie_detection
 
         return detection
 
-    async def emulate(self, data, session, path):
+    async def emulate(self, data, session):
         if data['method'] == 'POST':
             detection = await self.handle_post(session, data)
         else:
-            detection = await self.handle_get(session, path)
+            detection = await self.handle_get(session, data)
 
         return detection
 
-    async def handle(self, data, session, path):
-        detection = await self.emulate(data, session, path)
+    async def handle(self, data, session):
+        detection = await self.emulate(data, session)
         return detection

--- a/tanner/emulators/cmd_exec.py
+++ b/tanner/emulators/cmd_exec.py
@@ -64,7 +64,7 @@ class CmdExecEmulator:
             container.kill()
         except docker.errors.APIError as server_error:
             self.logger.error('Error while executing command %s in container %s', cmd, server_error)
-        result = dict(value= execute_result, page= '/index.html')
+        result = dict(value= execute_result)
         return result
 
     async def delete_env(self, container_name):

--- a/tanner/emulators/cmd_exec.py
+++ b/tanner/emulators/cmd_exec.py
@@ -75,25 +75,13 @@ class CmdExecEmulator:
         except docker.errors.APIError as server_error:
             self.logger.error('Error while removing container %s', server_error)
 
-    async def check_post_data(self, data):
-        cmd_data = []
-        for (param_id, param_value) in data['post_data'].items():
-            if patterns.CMD_ATTACK.match(param_value):
-                cmd_data.append((param_id, param_value))
-        return cmd_data
-        
-    async def check_get_data(self, path):
-        cmd_data = []
-        query = yarl.URL(path).query_string
-        params = query.split('&')
-        for param in params:
-            if len(param.split('=')) == 2:
-                param_id, param_value = param.split('=')
-                if patterns.CMD_ATTACK.match(param_value):
-                    cmd_data.append((param_id, param_value))
-        return cmd_data
+    def scan(self, value):
+        detection = None
+        if patterns.CMD_ATTACK.match(value):
+            detection = dict(name= 'cmd_exec', order= 3)
+        return detection
 
-    async def handle(self, value, session= None):
+    async def handle(self, attack_params, session= None):
         container = await self.create_attacker_env(session)
-        result = await self.get_cmd_exec_results(container, value)
+        result = await self.get_cmd_exec_results(container, attack_params[0]['value'])
         return result

--- a/tanner/emulators/lfi.py
+++ b/tanner/emulators/lfi.py
@@ -50,10 +50,15 @@ class LfiEmulator:
                     with open(filename, 'w') as vd:
                         vd.write(value)
 
+    def scan(self, value):
+        detection = None
+        if patterns.LFI_ATTACK.match(value):
+            detection = dict(name= 'lfi', order= 2)
+        return detection
 
-    async def handle(self, path, session=None):
+    async def handle(self, attack_params, session=None):
         if not self.whitelist:
             self.available_files()
-        file_path = self.get_file_path(path)
+        file_path = self.get_file_path(attack_params[0]['value'])
         result = self.get_lfi_result(file_path)
         return result

--- a/tanner/emulators/rfi.py
+++ b/tanner/emulators/rfi.py
@@ -38,14 +38,12 @@ class RfiEmulator:
 
         else:
             try:
-                with aiohttp.ClientSession(loop=self._loop) as client:
-                    resp = await client.get(url)
-                    data = await resp.text()
+                async with aiohttp.ClientSession(loop=self._loop) as client:
+                    async with client.get(url) as resp:
+                        data = await resp.text()
             except aiohttp.ClientError as client_error:
                 self.logger.error('Error during downloading the rfi script %s', client_error)
             else:
-                await resp.release()
-                await client.close()
                 tmp_filename = url.name + str(time.time())
                 file_name = hashlib.md5(tmp_filename.encode('utf-8')).hexdigest()
                 with open(os.path.join(self.script_dir, file_name), 'bw') as rfile:
@@ -79,10 +77,9 @@ class RfiEmulator:
         with open(os.path.join(self.script_dir, file_name), 'br') as script:
             script_data = script.read()
         try:
-            with aiohttp.ClientSession(loop=self._loop) as session:
-                
-                resp = await session.post('http://127.0.0.1:8088/', data=script_data)
-                rfi_result = await resp.json()
+            async with aiohttp.ClientSession(loop=self._loop) as session:
+                async with session.post('http://127.0.0.1:8088/', data=script_data) as resp:
+                    rfi_result = await resp.json()
         except aiohttp.ClientError as client_error:
             self.logger.error('Error during connection to php sandbox %s', client_error)
         else:

--- a/tanner/emulators/rfi.py
+++ b/tanner/emulators/rfi.py
@@ -90,8 +90,14 @@ class RfiEmulator:
             await session.close()
         return rfi_result
 
-    async def handle(self, path, session=None):
-        result = await self.get_rfi_result(path)
+    def scan(self, value):
+        detection = None
+        if patterns.RFI_ATTACK.match(value):
+            detection = dict(name= 'rfi', order= 2)
+        return detection
+
+    async def handle(self, attack_params, session=None):
+        result = await self.get_rfi_result(attack_params[0]['value'])
         if not result or 'stdout' not in result:
             return ''
         else:

--- a/tanner/emulators/sqli.py
+++ b/tanner/emulators/sqli.py
@@ -52,7 +52,7 @@ class SqliEmulator:
             execute_result = await self.sqli_emulator.execute_query(db_query, attacker_db)
             if isinstance(execute_result, list):
                 execute_result = ' '.join([str(x) for x in execute_result])
-            result = dict(value=execute_result, page='/index.html')
+            result = dict(value=execute_result)
         return result
 
     async def handle(self, attack_params, session):

--- a/tanner/emulators/sqli.py
+++ b/tanner/emulators/sqli.py
@@ -17,7 +17,6 @@ class SqliEmulator:
         self.query_map = None
 
     def scan(self, value):
-        print(value)
         detection = None
         payload = bytes(value, 'utf-8')
         sqli = pylibinjection.detect_sqli(payload)

--- a/tanner/emulators/xss.py
+++ b/tanner/emulators/xss.py
@@ -15,25 +15,11 @@ class XssEmulator:
 
     def get_xss_result(self, session, attack_params):
         result = None
-        injectable_page = None
         value = ''
-        if session:
-            injectable_page = self.set_xss_page(session)
-        if injectable_page is None:
-            injectable_page = '/index.html'
         for param in attack_params:
             value += param['value'] if not value else '\n' + param['value']
-        result = dict(value=value,
-                      page=injectable_page)
+        result = dict(value=value)
         return result
-
-    @staticmethod
-    def set_xss_page(session):
-        injectable_page = None
-        for page in reversed(session.paths):
-            if mimetypes.guess_type(page['path'])[0] == 'text/html':
-                injectable_page = page['path']
-        return injectable_page
 
     async def handle(self, attack_params, session):
         xss_result = None

--- a/tanner/server.py
+++ b/tanner/server.py
@@ -53,7 +53,7 @@ class TannerServer:
             )
             self.logger.info('Requested path %s', path)
             await self.dorks.extract_path(path, self.redis_client)
-            detection = await self.base_handler.handle(data, session, path)
+            detection = await self.base_handler.handle(data, session)
             session.set_attack_type(path, detection["name"])
 
             response_msg = self._make_response(msg=dict(detection=detection, sess_uuid=session.get_uuid()))

--- a/tanner/session_manager.py
+++ b/tanner/session_manager.py
@@ -71,7 +71,6 @@ class SessionManager:
             if not sess.is_expired():
                 continue
             await sess.remove_associated_db()
-            sess.remove_associated_db()
             await sess.remove_associated_env()
             self.sessions.remove(sess)
             try:

--- a/tanner/tests/test_base.py
+++ b/tanner/tests/test_base.py
@@ -15,53 +15,66 @@ class TestBase(unittest.TestCase):
         with mock.patch('tanner.emulators.lfi.LfiEmulator', mock.Mock(), create=True):
             self.handler = base.BaseHandler('/tmp/', 'test.db', self.loop)
 
-    def test_handle_get_sqli(self):
+        def mock_lfi_scan(value):
+            return dict(name= 'lfi', order= 0)
+
+        self.handler.emulators['lfi'].scan = mock_lfi_scan
+
+    def test_handle_sqli(self):
         path = '/index.html?id=1 UNION SELECT 1'
 
-        async def mock_sqli_check_get_data(path):
-            return 1
-
-        async def mock_sqli_handle(path, session, post_request=0):
+        async def mock_sqli_handle(path, session):
             return 'sqli_test_payload'
 
+        def mock_sqli_scan(value):
+            return dict(name= 'sqli', order= 2)
+
         self.handler.emulators['sqli'] = mock.Mock()
-        self.handler.emulators['sqli'].check_get_data = mock_sqli_check_get_data
         self.handler.emulators['sqli'].handle = mock_sqli_handle
+        self.handler.emulators['sqli'].scan = mock_sqli_scan
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
 
         assert_detection = {'name': 'sqli', 'order': 2, 'payload': 'sqli_test_payload'}
         self.assertDictEqual(detection, assert_detection)
 
-    def test_handle_get_xss(self):
+    def test_handle_xss(self):
         path = '/index.html?id=<script>alert(1);</script>'
 
-        async def mock_xss_handle(path, session, post_request=0):
+        async def mock_xss_handle(path, session):
             return 'xss_test_payload'
+
+        def mock_xss_scan(value):
+            return dict(name= 'xss', order= 3)
 
         self.handler.emulators['xss'] = mock.Mock()
         self.handler.emulators['xss'].handle = mock_xss_handle
+        self.handler.emulators['xss'].scan = mock_xss_scan
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
 
         assert_detection = {'name': 'xss', 'order': 3, 'payload': 'xss_test_payload'}
         self.assertDictEqual(detection, assert_detection)
 
-    def test_handle_get_lfi(self):
+    def test_handle_lfi(self):
         path = '/index.html?file=/etc/passwd'
 
-        async def mock_lfi_handle(path, session, post_request=0):
+        async def mock_lfi_handle(attack_value, session):
             return 'lfi_test_payload'
+        
+        def mock_lfi_scan(value):
+            return dict(name= 'lfi', order= 2)
 
         self.handler.emulators['lfi'] = mock.Mock()
         self.handler.emulators['lfi'].handle = mock_lfi_handle
+        self.handler.emulators['lfi'].scan = mock_lfi_scan
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
 
         assert_detection = {'name': 'lfi', 'order': 2, 'payload': 'lfi_test_payload'}
         self.assertDictEqual(detection, assert_detection)
 
-    def test_handle_get_index(self):
+    def test_handle_index(self):
         path = '/index.html'
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
@@ -69,7 +82,7 @@ class TestBase(unittest.TestCase):
         assert_detection = detection = {'name': 'index', 'order': 1}
         self.assertDictEqual(detection, assert_detection)
 
-    def test_handle_get_wp_content(self):
+    def test_handle_wp_content(self):
         path = '/wp-content'
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
@@ -77,38 +90,20 @@ class TestBase(unittest.TestCase):
         assert_detection = detection = {'name': 'wp-content', 'order': 1}
         self.assertDictEqual(detection, assert_detection)
 
-    def test_handle_get_rfi(self):
+    def test_handle_rfi(self):
         path = '/index.html?file=http://attack.php'
 
-        async def mock_rfi_handle(path, session, post_request=0):
+        async def mock_rfi_handle(path, session):
             return 'rfi_test_payload'
+
+        def mock_rfi_scan(value):
+            return dict(name= 'rfi', order= 2)
 
         self.handler.emulators['rfi'] = mock.Mock()
         self.handler.emulators['rfi'].handle = mock_rfi_handle
+        self.handler.emulators['rfi'].scan = mock_rfi_scan
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
 
         assert_detection = {'name': 'rfi', 'order': 2, 'payload': 'rfi_test_payload'}
-        self.assertDictEqual(detection, assert_detection)
-
-    def test_handle_post_xss(self):
-        async def mock_xss_handle(value, session, raw_data=None):
-            return 'xss_test_payload'
-
-        self.handler.emulators['xss'] = mock.Mock()
-        self.handler.emulators['xss'].handle = mock_xss_handle
-
-        async def mock_sqli_check_post_data(data):
-            return 1
-
-        async def mock_sqli_handle(path, session, post_request=0):
-            return None
-
-        self.handler.emulators['sqli'] = mock.Mock()
-        self.handler.emulators['sqli'].check_post_data = mock_sqli_check_post_data
-        self.handler.emulators['sqli'].handle = mock_sqli_handle
-
-        detection = self.loop.run_until_complete(self.handler.handle_post(self.session, self.data))
-
-        assert_detection = {'name': 'xss', 'order': 2, 'payload': 'xss_test_payload'}
         self.assertDictEqual(detection, assert_detection)

--- a/tanner/tests/test_base.py
+++ b/tanner/tests/test_base.py
@@ -21,7 +21,8 @@ class TestBase(unittest.TestCase):
         self.handler.emulators['lfi'].scan = mock_lfi_scan
 
     def test_handle_sqli(self):
-        path = '/index.html?id=1 UNION SELECT 1'
+        data = dict(path= '/index.html?id=1 UNION SELECT 1',
+                    cookies= {'sess_uuid': '9f82e5d0e6b64047bba996222d45e72c'})
 
         async def mock_sqli_handle(path, session):
             return 'sqli_test_payload'
@@ -33,13 +34,14 @@ class TestBase(unittest.TestCase):
         self.handler.emulators['sqli'].handle = mock_sqli_handle
         self.handler.emulators['sqli'].scan = mock_sqli_scan
 
-        detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
+        detection = self.loop.run_until_complete(self.handler.handle_get(self.session, data))
 
         assert_detection = {'name': 'sqli', 'order': 2, 'payload': 'sqli_test_payload'}
         self.assertDictEqual(detection, assert_detection)
 
     def test_handle_xss(self):
-        path = '/index.html?id=<script>alert(1);</script>'
+        data = dict(path= '/index.html?id=<script>alert(1);</script>',
+                    cookies= {'sess_uuid': '9f82e5d0e6b64047bba996222d45e72c'})
 
         async def mock_xss_handle(path, session):
             return 'xss_test_payload'
@@ -51,13 +53,14 @@ class TestBase(unittest.TestCase):
         self.handler.emulators['xss'].handle = mock_xss_handle
         self.handler.emulators['xss'].scan = mock_xss_scan
 
-        detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
+        detection = self.loop.run_until_complete(self.handler.handle_get(self.session, data))
 
         assert_detection = {'name': 'xss', 'order': 3, 'payload': 'xss_test_payload'}
         self.assertDictEqual(detection, assert_detection)
 
     def test_handle_lfi(self):
-        path = '/index.html?file=/etc/passwd'
+        data = dict(path= '/index.html?file=/etc/passwd',
+                    cookies= {'sess_uuid': '9f82e5d0e6b64047bba996222d45e72c'})
 
         async def mock_lfi_handle(attack_value, session):
             return 'lfi_test_payload'
@@ -69,29 +72,32 @@ class TestBase(unittest.TestCase):
         self.handler.emulators['lfi'].handle = mock_lfi_handle
         self.handler.emulators['lfi'].scan = mock_lfi_scan
 
-        detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
+        detection = self.loop.run_until_complete(self.handler.handle_get(self.session, data))
 
         assert_detection = {'name': 'lfi', 'order': 2, 'payload': 'lfi_test_payload'}
         self.assertDictEqual(detection, assert_detection)
 
     def test_handle_index(self):
-        path = '/index.html'
+        data = dict(path= '/index.html',
+                    cookies= {'sess_uuid': '9f82e5d0e6b64047bba996222d45e72c'})
 
-        detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
+        detection = self.loop.run_until_complete(self.handler.handle_get(self.session, data))
 
         assert_detection = detection = {'name': 'index', 'order': 1}
         self.assertDictEqual(detection, assert_detection)
 
     def test_handle_wp_content(self):
-        path = '/wp-content'
+        data = dict(path= '/wp-content',
+                    cookies= {'sess_uuid': '9f82e5d0e6b64047bba996222d45e72c'})
 
-        detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
+        detection = self.loop.run_until_complete(self.handler.handle_get(self.session, data))
 
         assert_detection = detection = {'name': 'wp-content', 'order': 1}
         self.assertDictEqual(detection, assert_detection)
 
     def test_handle_rfi(self):
-        path = '/index.html?file=http://attack.php'
+        data = dict(path= '/index.html?file=http://attack.php',
+                    cookies= {'sess_uuid': '9f82e5d0e6b64047bba996222d45e72c'})
 
         async def mock_rfi_handle(path, session):
             return 'rfi_test_payload'
@@ -103,7 +109,7 @@ class TestBase(unittest.TestCase):
         self.handler.emulators['rfi'].handle = mock_rfi_handle
         self.handler.emulators['rfi'].scan = mock_rfi_scan
 
-        detection = self.loop.run_until_complete(self.handler.handle_get(self.session, path))
+        detection = self.loop.run_until_complete(self.handler.handle_get(self.session, data))
 
         assert_detection = {'name': 'rfi', 'order': 2, 'payload': 'rfi_test_payload'}
         self.assertDictEqual(detection, assert_detection)

--- a/tanner/tests/test_base.py
+++ b/tanner/tests/test_base.py
@@ -2,6 +2,7 @@ import asyncio
 import unittest
 from unittest import mock
 
+from tanner import session
 from tanner.emulators import base
 
 
@@ -113,3 +114,13 @@ class TestBase(unittest.TestCase):
 
         assert_detection = {'name': 'rfi', 'order': 2, 'payload': 'rfi_test_payload'}
         self.assertDictEqual(detection, assert_detection)
+
+    def test_set_injectable_page(self):
+        paths = [{'path': '/python.html', 'timestamp': 1465851064.2740946},
+                 {'path': '/python.php/?foo=bar', 'timestamp': 1465851065.2740946},
+                 {'path': '/python.html/?foo=bar', 'timestamp': 1465851065.2740946}]
+        with mock.patch('tanner.session.Session') as mock_session:
+            mock_session.return_value.paths = paths
+            sess = session.Session(None)
+        injectable_page = self.handler.set_injectable_page(sess)
+        self.assertEqual(injectable_page, '/python.html')

--- a/tanner/tests/test_lfi_emulator.py
+++ b/tanner/tests/test_lfi_emulator.py
@@ -15,19 +15,16 @@ class TestLfiEmulator(unittest.TestCase):
         self.handler = lfi.LfiEmulator('/tmp/')
 
     def test_handle_abspath_lfi(self):
-        path = '/?foo=/etc/passwd'
-        query = yarl.URL(path).query
-        result = self.loop.run_until_complete(self.handler.handle(query['foo']))
+        attack_params = [dict(id= 'foo', value= '/etc/passwd')]
+        result = self.loop.run_until_complete(self.handler.handle(attack_params))
         self.assertIn('root:x:0:0:root:/root:/bin/bash', result)
 
     def test_handle_relative_path_lfi(self):
-        path = '/?foo=../../../../../etc/passwd'
-        query = yarl.URL(path).query
-        result = self.loop.run_until_complete(self.handler.handle(query['foo']))
+        attack_params = [dict(id= 'foo', value= '../../../../../etc/passwd')]
+        result = self.loop.run_until_complete(self.handler.handle(attack_params))
         self.assertIn('root:x:0:0:root:/root:/bin/bash', result)
 
     def test_handle_missing_lfi(self):
-        path = '/?foo=../../../../../etc/bar'
-        query = yarl.URL(path).query
-        result = self.loop.run_until_complete(self.handler.handle(query['foo']))
+        attack_params = [dict(id= 'foo', value= '../../../../../etc/bar')]
+        result = self.loop.run_until_complete(self.handler.handle(attack_params))
         self.assertIsNone(result)

--- a/tanner/tests/test_sqli.py
+++ b/tanner/tests/test_sqli.py
@@ -47,9 +47,7 @@ class SqliTest(unittest.TestCase):
         self.handler.sqli_emulator = mock.Mock()
         self.handler.sqli_emulator.execute_query = mock_execute_query
 
-        assert_result = dict(value="[1, 'name', 'email@mail.com', 'password'] [1, '2', '3', '4']",
-                             page='/index.html'
-                             )
+        assert_result = dict(value="[1, 'name', 'email@mail.com', 'password'] [1, '2', '3', '4']")
         result = self.loop.run_until_complete(self.handler.get_sqli_result(attack_value, 'foo.db'))
         self.assertEqual(assert_result, result)
 

--- a/tanner/tests/test_sqli.py
+++ b/tanner/tests/test_sqli.py
@@ -22,24 +22,24 @@ class SqliTest(unittest.TestCase):
         self.handler.query_map = query_map
 
     def test_map_query_id(self):
-        query = [('id', '1\'UNION SELECT 1,2,3,4')]
+        attack_value = dict(id= 'id', value= '1\'UNION SELECT 1,2,3,4')
         assert_result = 'SELECT * from users WHERE id=1 UNION SELECT 1,2,3,4;'
-        result = self.handler.map_query(query)
+        result = self.handler.map_query(attack_value)
         self.assertEqual(assert_result, result)
 
     def test_map_query_comments(self):
-        query = [('comment', 'some_comment" UNION SELECT 1,2 AND "1"="1')]
+        attack_value = dict(id= 'comment', value= 'some_comment" UNION SELECT 1,2 AND "1"="1')
         assert_result = 'SELECT * from comments WHERE comment="some_comment" UNION SELECT 1,2 AND "1"="1";'
-        result = self.handler.map_query(query)
+        result = self.handler.map_query(attack_value)
         self.assertEqual(assert_result, result)
 
     def test_map_query_error(self):
-        query = [('foo', 'bar\'UNION SELECT 1,2')]
-        result = self.handler.map_query(query)
+        attack_value = dict(id= 'foo', value= 'bar\'UNION SELECT 1,2')
+        result = self.handler.map_query(attack_value)
         self.assertIsNone(result)
 
     def test_get_sqli_result(self):
-        query = [('id', '1 UNION SELECT 1,2,3,4')]
+        attack_value = dict(id= 'id', value= '1 UNION SELECT 1,2,3,4')
 
         async def mock_execute_query(query, db_name):
             return [[1, 'name', 'email@mail.com', 'password'], [1, '2', '3', '4']]
@@ -50,13 +50,13 @@ class SqliTest(unittest.TestCase):
         assert_result = dict(value="[1, 'name', 'email@mail.com', 'password'] [1, '2', '3', '4']",
                              page='/index.html'
                              )
-        result = self.loop.run_until_complete(self.handler.get_sqli_result(query, 'foo.db'))
+        result = self.loop.run_until_complete(self.handler.get_sqli_result(attack_value, 'foo.db'))
         self.assertEqual(assert_result, result)
 
     def test_get_sqli_result_error(self):
-        query = [('foo', 'bar\'UNION SELECT 1,2')]
+        attack_value = dict(id= 'foo', value= 'bar\'UNION SELECT 1,2')
         assert_result = 'You have an error in your SQL syntax; check the manual\
                         that corresponds to your MySQL server version for the\
                         right syntax to use near foo at line 1'
-        result = self.loop.run_until_complete(self.handler.get_sqli_result(query, 'foo.db'))
+        result = self.loop.run_until_complete(self.handler.get_sqli_result(attack_value, 'foo.db'))
         self.assertEqual(assert_result, result)

--- a/tanner/tests/test_xss_emulator.py
+++ b/tanner/tests/test_xss_emulator.py
@@ -3,7 +3,6 @@ import asyncio
 import unittest
 from unittest import mock
 
-from tanner import session
 from tanner.emulators import xss
 
 
@@ -25,17 +24,5 @@ class TestXSSEmulator(unittest.TestCase):
         attack_params = [dict(id= 'foo', value= '<script>alert(\'xss\');</script>')]
         xss = self.loop.run_until_complete(self.handler.handle(attack_params, None))
 
-        assert_result = dict(value=attack_params[0]['value'],
-                             page='/index.html')
+        assert_result = dict(value=attack_params[0]['value'])
         self.assertDictEqual(xss, assert_result)
-
-    def test_set_xss_page(self):
-        paths = [{'path': '/python.html', 'timestamp': 1465851064.2740946},
-                 {'path': '/python.php/?foo=bar', 'timestamp': 1465851065.2740946},
-                 {'path': '/python.html/?foo=bar', 'timestamp': 1465851065.2740946}]
-        with mock.patch('tanner.session.Session') as mock_session:
-            mock_session.return_value.paths = paths
-            sess = session.Session(None)
-        attack_params = [dict(id= 'foo', value= '<script>alert(\'xss\');</script>')]
-        xss = self.loop.run_until_complete(self.handler.handle(attack_params, sess))
-        self.assertEqual(xss['page'], '/python.html')


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/travis/build/mushorg/tanner/tanner/tests/test_rfi_emulation.py", line 16, in test_http_download
    data = self.loop.run_until_complete(self.handler.download_file(path))
  File "uvloop/loop.pyx", line 1203, in uvloop.loop.Loop.run_until_complete (uvloop/loop.c:25632)
  File "uvloop/future.pyx", line 146, in uvloop.loop.BaseFuture.result (uvloop/loop.c:109361)
  File "uvloop/future.pyx", line 101, in uvloop.loop.BaseFuture._result_impl (uvloop/loop.c:108900)
  File "uvloop/future.pyx", line 372, in uvloop.loop.BaseTask._fast_step (uvloop/loop.c:112669)
  File "/home/travis/build/mushorg/tanner/tanner/emulators/rfi.py", line 48, in download_file
    await client.close()
TypeError: object _CoroGuard can't be used in 'await' expression
```