### PR TITLE
Rfi fixes

### DIFF
--- a/tanner/emulators/rfi.py
+++ b/tanner/emulators/rfi.py
@@ -38,14 +38,12 @@ class RfiEmulator:
 
         else:
             try:
-                with aiohttp.ClientSession(loop=self._loop) as client:
-                    resp = await client.get(url)
-                    data = await resp.text()
+                async with aiohttp.ClientSession(loop=self._loop) as client:
+                    async with await client.get(url) as resp:
+                        data = await resp.text()
             except aiohttp.ClientError as client_error:
                 self.logger.error('Error during downloading the rfi script %s', client_error)
             else:
-                await resp.release()
-                await client.close()
                 tmp_filename = url.name + str(time.time())
                 file_name = hashlib.md5(tmp_filename.encode('utf-8')).hexdigest()
                 with open(os.path.join(self.script_dir, file_name), 'bw') as rfile:
@@ -79,10 +77,9 @@ class RfiEmulator:
         with open(os.path.join(self.script_dir, file_name), 'br') as script:
             script_data = script.read()
         try:
-            with aiohttp.ClientSession(loop=self._loop) as session:
-                
-                resp = await session.post('http://127.0.0.1:8088/', data=script_data)
-                rfi_result = await resp.json()
+            async with aiohttp.ClientSession(loop=self._loop) as session:
+                async with session.post('http://127.0.0.1:8088/', data=script_data) as resp:
+                    rfi_result = await resp.json()
         except aiohttp.ClientError as client_error:
             self.logger.error('Error during connection to php sandbox %s', client_error)
         else:

--- a/tanner/session_manager.py
+++ b/tanner/session_manager.py
@@ -71,7 +71,6 @@ class SessionManager:
             if not sess.is_expired():
                 continue
             await sess.remove_associated_db()
-            sess.remove_associated_db()
             await sess.remove_associated_env()
             self.sessions.remove(sess)
             try:


### PR DESCRIPTION
Fix error in rfi
```
Traceback (most recent call last):
  File "/home/travis/build/mushorg/tanner/tanner/tests/test_rfi_emulation.py", line 16, in test_http_download
    data = self.loop.run_until_complete(self.handler.download_file(path))
  File "uvloop/loop.pyx", line 1203, in uvloop.loop.Loop.run_until_complete (uvloop/loop.c:25632)
  File "uvloop/future.pyx", line 146, in uvloop.loop.BaseFuture.result (uvloop/loop.c:109361)
  File "uvloop/future.pyx", line 101, in uvloop.loop.BaseFuture._result_impl (uvloop/loop.c:108900)
  File "uvloop/future.pyx", line 372, in uvloop.loop.BaseTask._fast_step (uvloop/loop.c:112669)
  File "/home/travis/build/mushorg/tanner/tanner/emulators/rfi.py", line 48, in download_file
    await client.close()
TypeError: object _CoroGuard can't be used in 'await' expression
```