### PR TITLE
Close redis connections on shutdown

### DIFF
--- a/tanner/server.py
+++ b/tanner/server.py
@@ -87,6 +87,9 @@ class TannerServer:
         response_msg = dict(version=1, response=dict(dorks=dorks))
         return web.json_response(response_msg)
 
+    async def on_shutdown(self, app):
+        self.redis_client.close()
+        
     def setup_routes(self, app):
         app.router.add_route('*', '/', self.default_handler)
         app.router.add_post('/event', self.handle_event)
@@ -96,6 +99,7 @@ class TannerServer:
 
     def create_app(self, loop):
         app = web.Application(loop=loop)
+        app.on_shutdown.append(self.on_shutdown)
         self.setup_routes(app)
         return app
 

--- a/tanner/tests/test_server.py
+++ b/tanner/tests/test_server.py
@@ -24,6 +24,7 @@ class TestServer(AioHTTPTestCase):
 
         self.test_uuid = uuid.uuid4()
 
+
         async def _add_or_update_mock(data, client):
             sess = mock.Mock()
             sess.set_attack_type = mock.Mock()
@@ -40,7 +41,10 @@ class TestServer(AioHTTPTestCase):
         dorks.choose_dorks = choosed
         dorks.extract_path = self._make_coroutine()
 
+        redis = mock.Mock()
+        redis.close = mock.Mock()
         self.serv.dorks = dorks
+        self.serv.redis_client = redis
 
         super(TestServer, self).setUp()
 


### PR DESCRIPTION
Prevent redis error on shutdown. 
```
ERROR:asyncio:(unknown function): Task was destroyed but it is pending!
task: <Task pending coro=<RedisProtocol._reader_coroutine() running at /usr/lib/python3.6/site-packages/asyncio_redis/protocol.py:941> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7f8bc96d1138>()]>>
```