### PR TITLE
Snare tanner communication

### DIFF
--- a/tanner/emulators/base.py
+++ b/tanner/emulators/base.py
@@ -117,7 +117,7 @@ class BaseHandler:
         if 'payload' not in detection:
             detection['type'] = 1
         elif 'payload' in detection:
-            if 'status_code' not in detection:
+            if 'status_code' not in detection['payload']:
                 detection['type'] = 2
                 if detection['payload']['page']:
                     injectable_page = self.set_injectable_page(session)

--- a/tanner/emulators/base.py
+++ b/tanner/emulators/base.py
@@ -58,11 +58,12 @@ class BaseHandler:
 	                    if emulator not in attack_params:
 	                        attack_params[emulator] = []
 	                    attack_params[emulator].append(dict(id=param_id, value=param_value))
-                    
+
         if detection['name'] in self.emulators:
             emulation_result = await self.emulators[detection['name']].handle(attack_params[detection['name']], session)
-            detection['payload'] = emulation_result
-
+            if emulation_result:
+                detection['payload'] = emulation_result
+                
         return detection
 
     async def handle_post(self, session, data):
@@ -113,11 +114,18 @@ class BaseHandler:
         else:
             detection = await self.handle_get(session, data)
         
-        if 'payload' in detection and type(detection['payload']) is dict:
-            injectable_page = self.set_injectable_page(session)
-            if injectable_page is None:
-                injectable_page = '/index.html'
-            detection['payload']['page'] = injectable_page
+        if 'payload' not in detection:
+            detection['type'] = 1
+        elif 'payload' in detection:
+            if 'status_code' not in detection:
+                detection['type'] = 2
+                if detection['payload']['page']:
+                    injectable_page = self.set_injectable_page(session)
+                    if injectable_page is None:
+                        injectable_page = '/index.html'
+                    detection['payload']['page'] = injectable_page
+            else:
+                detection['type'] = 3
 
         return detection
 

--- a/tanner/emulators/cmd_exec.py
+++ b/tanner/emulators/cmd_exec.py
@@ -17,7 +17,7 @@ class CmdExecEmulator:
 
     async def get_cmd_exec_results(self, container, cmd):
         execute_result = await self.helper.execute_cmd(container, cmd)
-        result = dict(value= execute_result, page= '/index.html')
+        result = dict(value=execute_result, page=True)
         return result
 
     def scan(self, value):

--- a/tanner/emulators/lfi.py
+++ b/tanner/emulators/lfi.py
@@ -35,5 +35,6 @@ class LfiEmulator:
         result = None
         container = await self.setup_virtual_env()
         if container:
-            result = await self.get_lfi_result(container, attack_params[0]['value'])
+            lfi_result = await self.get_lfi_result(container, attack_params[0]['value'])
+            result = dict(value=lfi_result, page=False)
         return result

--- a/tanner/emulators/php_code_injection.py
+++ b/tanner/emulators/php_code_injection.py
@@ -31,5 +31,5 @@ class PHPCodeInjection:
     async def handle(self, attack_params, session=None):
         result = await self.get_injection_result(attack_params[0]['value'])
         if not result or 'stdout' not in result:
-            return ''
-        return result['stdout']
+            return dict(status_code=504) 
+        return dict(value=result['stdout'], page=False)

--- a/tanner/emulators/rfi.py
+++ b/tanner/emulators/rfi.py
@@ -96,6 +96,6 @@ class RfiEmulator:
     async def handle(self, attack_params, session=None):
         result = await self.get_rfi_result(attack_params[0]['value'])
         if not result or 'stdout' not in result:
-            return ''
+            return dict(value='', page=True)
         else:
-            return result['stdout']
+            return dict(value=result['stdout'], page=False)

--- a/tanner/emulators/sqli.py
+++ b/tanner/emulators/sqli.py
@@ -52,7 +52,7 @@ class SqliEmulator:
             execute_result = await self.sqli_emulator.execute_query(db_query, attacker_db)
             if isinstance(execute_result, list):
                 execute_result = ' '.join([str(x) for x in execute_result])
-            result = dict(value=execute_result)
+            result = dict(value=execute_result, page=True)
         return result
 
     async def handle(self, attack_params, session):

--- a/tanner/emulators/xss.py
+++ b/tanner/emulators/xss.py
@@ -18,7 +18,7 @@ class XssEmulator:
         value = ''
         for param in attack_params:
             value += param['value'] if not value else '\n' + param['value']
-        result = dict(value=value)
+        result = dict(value=value, page=True)
         return result
 
     async def handle(self, attack_params, session):

--- a/tanner/tests/test_lfi_emulator.py
+++ b/tanner/tests/test_lfi_emulator.py
@@ -13,14 +13,14 @@ class TestLfiEmulator(unittest.TestCase):
     def test_handle_abspath_lfi(self):
         attack_params = [dict(id= 'foo', value= '/etc/passwd')]
         result = self.loop.run_until_complete(self.handler.handle(attack_params))
-        self.assertIn('root:x:0:0:root:/root:/bin/sh', result)
+        self.assertIn('root:x:0:0:root:/root:/bin/sh', result['value'])
 
     def test_handle_relative_path_lfi(self):
         attack_params = [dict(id= 'foo', value= '../../../../../etc/passwd')]
         result = self.loop.run_until_complete(self.handler.handle(attack_params))
-        self.assertIn('root:x:0:0:root:/root:/bin/sh', result)
+        self.assertIn('root:x:0:0:root:/root:/bin/sh', result['value'])
 
     def test_handle_missing_lfi(self):
         attack_params = [dict(id= 'foo', value= '../../../../../etc/bar')]
         result = self.loop.run_until_complete(self.handler.handle(attack_params))
-        self.assertIn('No such file or directory', result)
+        self.assertIn('No such file or directory', result['value'])

--- a/tanner/tests/test_sqli.py
+++ b/tanner/tests/test_sqli.py
@@ -47,7 +47,7 @@ class SqliTest(unittest.TestCase):
         self.handler.sqli_emulator = mock.Mock()
         self.handler.sqli_emulator.execute_query = mock_execute_query
 
-        assert_result = dict(value="[1, 'name', 'email@mail.com', 'password'] [1, '2', '3', '4']")
+        assert_result = dict(value="[1, 'name', 'email@mail.com', 'password'] [1, '2', '3', '4']", page=True)
         result = self.loop.run_until_complete(self.handler.get_sqli_result(attack_value, 'foo.db'))
         self.assertEqual(assert_result, result)
 

--- a/tanner/tests/test_xss_emulator.py
+++ b/tanner/tests/test_xss_emulator.py
@@ -24,5 +24,5 @@ class TestXSSEmulator(unittest.TestCase):
         attack_params = [dict(id= 'foo', value= '<script>alert(\'xss\');</script>')]
         xss = self.loop.run_until_complete(self.handler.handle(attack_params, None))
 
-        assert_result = dict(value=attack_params[0]['value'])
+        assert_result = dict(value=attack_params[0]['value'], page=True)
         self.assertDictEqual(xss, assert_result)


### PR DESCRIPTION
fix #100
This is how return value from tanner look like : 
```
Case 1 (where you need to return the page normally)
detection = {
		type : 1
        }
Case 2 (inject payload in the page)
detection = {
		type : 2,
payload = {
		page : ‘/vuln.php’,
		value : ‘<script>alert(1)</script>’
		headers : {
				new_header : ‘new_header_value’
			     }
	      }
        }
Case 3 (where input cause some error so return related to the type of error produced 
  e.g if input takes more time than expected then return 50X) 
detection = {
		type : 3,
                payload = {
		                  status_code : 500/504
                                 } 
       }

```

 
To make communication more systematic, return value type from each emulator is fixed i.e `dict(value='', page=True/False)` (if page=False then payload won't be injected on any page but on a new page)