### PR TITLE
Change required aiohttp version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=2.0
+aiohttp==2.2
 aiomysql
 aiohttp_jinja2
 docker


### PR DESCRIPTION
Tests with aiohttp2.3 gives error
Until the exact problem is defined, older version of aiohttp will be used 
```
ERROR: test_api_index_request (tanner.tests.test_api_server.TestAPIServer)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/mushorg/tanner/tanner/tests/test_api_server.py", line 17, in setUp
    super(TestAPIServer, self).setUp()
  File "/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages/aiohttp/test_utils.py", line 380, in setUp
    self.loop = setup_test_loop()
  File "/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages/aiohttp/test_utils.py", line 455, in setup_test_loop
    policy.set_child_watcher(watcher)
  File "/opt/python/3.5.3/lib/python3.5/asyncio/events.py", line 547, in set_child_watcher
    raise NotImplementedError
NotImplementedError
```