### PR TITLE
Use docker version <2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp==2.2
 aiomysql
 aiohttp_jinja2
-docker
+docker<2.6
 elizabeth==0.3.27
 yarl
 redis


### PR DESCRIPTION
Docker release 2.6 breaks tanner, use version less than 2.6
https://github.com/docker/docker-py/releases/tag/2.6.0