### PR TITLE
yarl <0.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiomysql
 aiohttp_jinja2
 docker<2.6
 elizabeth==0.3.27
-yarl
+yarl<0.14
 redis
 asyncio_redis
 uvloop


### PR DESCRIPTION
New yarl release dropped strict mode

```
aiohttp.server: ERROR: Error handling request
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages/aiohttp/web_protocol.py", line 278, in data_received
    messages, upgraded, tail = self._request_parser.feed_data(data)
  File "aiohttp/_http_parser.pyx", line 274, in aiohttp._http_parser.HttpParser.feed_data (aiohttp/_http_parser.c:4364)
  File "aiohttp/_http_parser.pyx", line 334, in aiohttp._http_parser.cb_on_url (aiohttp/_http_parser.c:5381)
  File "aiohttp/_http_parser.pyx", line 544, in aiohttp._http_parser._parse_url (aiohttp/_http_parser.c:8777)
  File "/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages/aiohttp/http_writer.py", line 317, in __init__
    path = yarl.quote(path, safe='@:', protected='/', strict=False)
  File "yarl/_quoting.pyx", line 38, in yarl._quoting._quote
TypeError: _quote() got an unexpected keyword argument 'strict'
```