### PR TITLE
Navigate to readthedocs.org and adding docs badge for the same

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-TANNER [![Build Status](https://travis-ci.org/mushorg/tanner.svg?branch=master)](https://travis-ci.org/mushorg/tanner)
+TANNER 
 ======
+[![Build Status](https://travis-ci.org/mushorg/tanner.svg?branch=master)](https://travis-ci.org/mushorg/tanner)
+[![Documentation Status](https://readthedocs.org/projects/tanner/badge/?version=latest)](http://tanner.readthedocs.io/en/latest/?badge=latest)
 
 <b>He who flays the hide</b>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 TANNER 
 ======
-[![Build Status](https://travis-ci.org/mushorg/tanner.svg?branch=master)](https://travis-ci.org/mushorg/tanner)
 [![Documentation Status](https://readthedocs.org/projects/tanner/badge/?version=latest)](http://tanner.readthedocs.io/en/latest/?badge=latest)
+[![Build Status](https://travis-ci.org/mushorg/tanner.svg?branch=master)](https://travis-ci.org/mushorg/tanner)
 
 <b><i>He who flays the hide</b></i>
 

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ Run ``sudo tannerweb``
 
 You obviously want to bind to 0.0.0.0 when running in <i>production</i> and on a different host than SNARE (recommended).
 
-[See the docs for more info](docs/source/index.rst)
+[See the docs for more info](http://tanner.readthedocs.io/en/latest/)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ TANNER
 [![Build Status](https://travis-ci.org/mushorg/tanner.svg?branch=master)](https://travis-ci.org/mushorg/tanner)
 [![Documentation Status](https://readthedocs.org/projects/tanner/badge/?version=latest)](http://tanner.readthedocs.io/en/latest/?badge=latest)
 
-<b>He who flays the hide</b>
-
+<b><i>He who flays the hide</b></i>
 
 Basic Concept
 -------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
-   .. _quick-start: docs/source/index.rst
+   quick-start
    emulators
    sessions
    storage

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
-   quick-start
+   .. _quick-start: docs/source/index.rst
    emulators
    sessions
    storage


### PR DESCRIPTION
As we have moved our docs to readthedocs.org, I think we should navigate to it through our README.md file. This is to make the navigation to the docs easier :)