### PR TITLE
Add seconds to logger time

### DIFF
--- a/tanner/utils/logger.py
+++ b/tanner/utils/logger.py
@@ -26,7 +26,7 @@ class Logger:
         logger.setLevel(logging.DEBUG)
         logger.propagate = False
         formatter = logging.Formatter(fmt='%(asctime)s %(levelname)s:%(name)s:%(funcName)s: %(message)s',
-                                      datefmt='%Y-%m-%d %H:%M')
+                                      datefmt='%Y-%m-%d %H:%M:%S')
 
         # ERROR log to 'tanner.err'
         error_log_handler = logging.handlers.RotatingFileHandler(err_filename, encoding='utf-8')


### PR DESCRIPTION
As discussed with  @glaslos this will add "seconds" to tanner logger.

Before these changes:
```
2018-03-01 18:04 INFO:asyncio_redis:connection_lost: Redis connection lost
```
After applying these changes:
```
2018-03-01 18:04:27 INFO:asyncio_redis:connection_lost: Redis connection lost
```