### PR TITLE
Adding tanner command line parameters to doc

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ Contents:
    :maxdepth: 2
 
    quick-start
+   parameters
    emulators
    sessions
    storage

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -1,0 +1,8 @@
+TANNER command line parameters
+=============================
+tanner [**--config**]
+
+Description
+~~~~~~~~~~~
+
+* **config** -- path to tanner config file


### PR DESCRIPTION
Even though we have only one parameter for tanner's command line, creating a doc for the same would be useful in the future , in case if we implement new command line parameters.