### PR TITLE
return json transformation

### DIFF
--- a/tanner/session_analyzer.py
+++ b/tanner/session_analyzer.py
@@ -20,6 +20,7 @@ class SessionAnalyzer:
         await asyncio.sleep(1, loop=self._loop)
         try:
             session = await redis_client.get(session_key, encoding='utf-8')
+            session = json.loads(session)
         except (aioredis.ProtocolError, TypeError, ValueError) as error:
             self.logger.error('Can\'t get session for analyze: %s', error)
         else:


### PR DESCRIPTION
Fixed the problem with session analyzing 

```
2018-07-19 15:34:40 ERROR:aiohttp.server:log_exception: Error handling request
Traceback (most recent call last):
  File "/usr/local/lib64/python3.5/site-packages/aiohttp/web_protocol.py", line 422, in start
    resp = yield from self._request_handler(request)
  File "/usr/local/lib64/python3.5/site-packages/aiohttp/web.py", line 306, in _handle
    resp = yield from handler(request)
  File "/usr/local/lib/python3.5/site-packages/Tanner-0.5.0-py3.5.egg/tanner/server.py", line 60, in handle_event
    data, self.redis_client
  File "/usr/local/lib/python3.5/site-packages/Tanner-0.5.0-py3.5.egg/tanner/session_manager.py", line 17, in add_or_update_session
    await self.delete_old_sessions(redis_client)
  File "/usr/local/lib/python3.5/site-packages/Tanner-0.5.0-py3.5.egg/tanner/session_manager.py", line 71, in delete_old_sessions
    is_deleted = await self.delete_session(sess, redis_client)
  File "/usr/local/lib/python3.5/site-packages/Tanner-0.5.0-py3.5.egg/tanner/session_manager.py", line 90, in delete_session
    await self.analyzer.analyze(sess.get_uuid(), redis_client)
  File "/usr/local/lib/python3.5/site-packages/Tanner-0.5.0-py3.5.egg/tanner/session_analyzer.py", line 26, in analyze
    result = await self.create_stats(session, redis_client)
  File "/usr/local/lib/python3.5/site-packages/Tanner-0.5.0-py3.5.egg/tanner/session_analyzer.py", line 44, in create_stats
    sess_duration = session['end_time'] - session['start_time']
TypeError: string indices must be integers
```

