### PR TITLE
Applied logging exceptions (Fix #238)

### DIFF
--- a/tanner/api/api.py
+++ b/tanner/api/api.py
@@ -14,7 +14,7 @@ class Api:
         try:
             query_res = await self.redis_client.smembers('snare_ids', encoding='utf-8')
         except aioredis.ProtocolError as connection_error:
-            self.logger.error('Can not connect to redis %s', connection_error)
+            self.logger.exception('Can not connect to redis %s', connection_error)
         return list(query_res)
 
     async def return_snare_stats(self, snare_uuid):
@@ -46,7 +46,7 @@ class Api:
                 uuid, offset=0, count=count, encoding='utf-8'
             )
         except aioredis.ProtocolError as connection_error:
-            self.logger.error('Can not connect to redis %s', connection_error)
+            self.logger.exception('Can not connect to redis %s', connection_error)
         else:
             if not query_res:
                 return 'Invalid SNARE UUID'

--- a/tanner/api/server.py
+++ b/tanner/api/server.py
@@ -56,7 +56,7 @@ class ApiServer:
                 if 'end_time' in applied_filters:
                     applied_filters['end_time'] = float(applied_filters['end_time'])
         except Exception as e:
-            self.logger.error('Filter error : %s' % e)
+            self.logger.exception('Filter error : %s' % e)
             result = 'Invalid filter definition'
         else:
             sessions = await self.api.return_sessions(applied_filters)

--- a/tanner/dorks_manager.py
+++ b/tanner/dorks_manager.py
@@ -40,7 +40,7 @@ class DorksManager:
             try:
                 await redis_client.sadd(self.user_dorks_key, *[extracted])
             except aioredis.ProtocolError as connection_error:
-                self.logger.error('Problem with redis connection: %s', connection_error)
+                self.logger.exception('Problem with redis connection: %s', connection_error)
 
     async def init_dorks(self, redis_client):
         try:
@@ -50,7 +50,7 @@ class DorksManager:
 
             await transaction.execute()
         except (aioredis.MultiExecError, aioredis.ProtocolError) as redis_error:
-            self.logger.error('Problem with transaction: %s', redis_error)
+            self.logger.exception('Problem with transaction: %s', redis_error)
         else:
             dorks_existed = await dorks_exist
             user_dorks_existed = await user_dorks_exist
@@ -75,7 +75,7 @@ class DorksManager:
 
             await transaction.execute()
         except (aioredis.MultiExecError, aioredis.ProtocolError) as redis_error:
-            self.logger.error('Problem with transaction: %s', redis_error)
+            self.logger.exception('Problem with transaction: %s', redis_error)
         else:
             dorks = await dorks
             user_dorks = await user_dorks

--- a/tanner/emulators/rfi.py
+++ b/tanner/emulators/rfi.py
@@ -43,7 +43,7 @@ class RfiEmulator:
                     async with await client.get(url) as resp:
                         data = await resp.text()
             except aiohttp.ClientError as client_error:
-                self.logger.error('Error during downloading the rfi script %s', client_error)
+                self.logger.exception('Error during downloading the rfi script %s', client_error)
             else:
                 tmp_filename = url.name + str(time.time())
                 file_name = hashlib.md5(tmp_filename.encode('utf-8')).hexdigest()
@@ -64,7 +64,7 @@ class RfiEmulator:
             with open(os.path.join(self.script_dir, file_name), 'wb') as ftp_script:
                 ftp.retrbinary('RETR %s' % name, ftp_script.write)
         except ftplib.all_errors as ftp_errors:
-            self.logger.error("Problem with ftp download %s", ftp_errors)
+            self.logger.exception("Problem with ftp download %s", ftp_errors)
             return None
         else:
             return file_name
@@ -85,7 +85,7 @@ class RfiEmulator:
                 async with session.post(phpox_address, data=script_data) as resp:
                     rfi_result = await resp.json()
         except aiohttp.ClientError as client_error:
-            self.logger.error('Error during connection to php sandbox %s', client_error)
+            self.logger.exception('Error during connection to php sandbox %s', client_error)
         else:
             await resp.release()
             await session.close()

--- a/tanner/redis_client.py
+++ b/tanner/redis_client.py
@@ -21,6 +21,6 @@ class RedisClient:
             redis_client = await asyncio.wait_for(aioredis.create_redis_pool(
                 (host, int(port)), maxsize=int(poolsize)), timeout=int(timeout))
         except asyncio.TimeoutError as timeout_error:
-            LOGGER.error('Problem with redis connection. Please, check your redis server. %s', timeout_error)
+            LOGGER.exception('Problem with redis connection. Please, check your redis server. %s', timeout_error)
             exit()
         return redis_client

--- a/tanner/server.py
+++ b/tanner/server.py
@@ -53,7 +53,7 @@ class TannerServer:
             data = json.loads(data.decode('utf-8'))
             path = yarl.URL(data['path']).human_repr()
         except (TypeError, ValueError, KeyError) as error:
-            self.logger.error('error parsing request: %s', data)
+            self.logger.exception('error parsing request: %s', data)
             response_msg = self._make_response(msg=type(error).__name__)
         else:
             session = await self.session_manager.add_or_update_session(

--- a/tanner/session_analyzer.py
+++ b/tanner/session_analyzer.py
@@ -37,8 +37,7 @@ class SessionAnalyzer:
                 await redis_client.zadd(s_key, session['start_time'], json.dumps(session))
                 await redis_client.delete(*[del_key])
             except aioredis.ProtocolError as redis_error:
-                self.logger.exception('Error with redis. Session will be returned to the queue: %s',
-                                  redis_error)
+                self.logger.exception('Error with redis. Session will be returned to the queue: %s', redis_error)
                 self.queue.put(session)
 
     async def create_stats(self, session, redis_client):

--- a/tanner/session_analyzer.py
+++ b/tanner/session_analyzer.py
@@ -22,7 +22,7 @@ class SessionAnalyzer:
             session = await redis_client.get(session_key, encoding='utf-8')
             session = json.loads(session)
         except (aioredis.ProtocolError, TypeError, ValueError) as error:
-            self.logger.error('Can\'t get session for analyze: %s', error)
+            self.logger.exception('Can\'t get session for analyze: %s', error)
         else:
             result = await self.create_stats(session, redis_client)
             await self.queue.put(result)
@@ -37,7 +37,7 @@ class SessionAnalyzer:
                 await redis_client.zadd(s_key, session['start_time'], json.dumps(session))
                 await redis_client.delete(*[del_key])
             except aioredis.ProtocolError as redis_error:
-                self.logger.error('Error with redis. Session will be returned to the queue: %s',
+                self.logger.exception('Error with redis. Session will be returned to the queue: %s',
                                   redis_error)
                 self.queue.put(session)
 

--- a/tanner/session_manager.py
+++ b/tanner/session_manager.py
@@ -24,7 +24,7 @@ class SessionManager:
             try:
                 new_session = Session(valid_data)
             except KeyError as key_error:
-                self.logger.error('Error during session creation: %s', key_error)
+                self.logger.exception('Error during session creation: %s', key_error)
                 return
             self.sessions.append(new_session)
             return new_session
@@ -89,7 +89,7 @@ class SessionManager:
             await redis_client.set(sess.get_uuid(), sess.to_json())
             await self.analyzer.analyze(sess.get_uuid(), redis_client)
         except aioredis.ProtocolError as redis_error:
-            self.logger.error('Error connect to redis, session stay in memory. %s', redis_error)
+            self.logger.exception('Error connect to redis, session stay in memory. %s', redis_error)
             return False
         else:
             return True

--- a/tanner/utils/docker_helper.py
+++ b/tanner/utils/docker_helper.py
@@ -12,7 +12,7 @@ class DockerHelper:
         try:
             self.docker_client = docker.from_env(version='auto')
         except docker.errors.APIError as docker_error:
-            self.logger.error('Error while connecting to docker service %s', docker_error)
+            self.logger.exception('Error while connecting to docker service %s', docker_error)
         self.host_image = TannerConfig.get('DOCKER', 'host_image')
 
     async def setup_host_image(self):
@@ -20,7 +20,7 @@ class DockerHelper:
             if not self.docker_client.images.list(self.host_image):
                 self.docker_client.images.pull(self.host_image)
         except docker.errors.APIError as docker_error:
-            self.logger.error('Error while pulling %s image %s', self.host_image, docker_error)
+            self.logger.exception('Error while pulling %s image %s', self.host_image, docker_error)
 
     async def get_container(self, container_name):
         container = None
@@ -31,7 +31,7 @@ class DockerHelper:
             if container_if_exists:
                 container = container_if_exists[0]
         except docker.errors.APIError as server_error:
-            self.logger.error('Error while fetching container list %s', server_error)
+            self.logger.exception('Error while fetching container list %s', server_error)
         return container
 
     async def create_container(self, container_name):
@@ -44,7 +44,7 @@ class DockerHelper:
                                                                  name=container_name
                                                                  )
             except (docker.errors.APIError, docker.errors.ImageNotFound) as docker_error:
-                self.logger.error('Error while creating a container %s', docker_error)
+                self.logger.exception('Error while creating a container %s', docker_error)
         return container
 
     async def delete_env(self, container_name):
@@ -53,7 +53,7 @@ class DockerHelper:
             if container:
                 container.remove(force=True)
         except docker.errors.APIError as server_error:
-            self.logger.error('Error while removing container %s', server_error)
+            self.logger.exception('Error while removing container %s', server_error)
 
     async def execute_cmd(self, container, cmd):
         execute_result = None
@@ -62,5 +62,5 @@ class DockerHelper:
             execute_result = container.exec_run(['sh', '-c', cmd]).decode('utf-8')
             container.kill()
         except docker.errors.APIError as server_error:
-            self.logger.error('Error while executing command %s in container %s', cmd, server_error)
+            self.logger.exception('Error while executing command %s in container %s', cmd, server_error)
         return execute_result

--- a/tanner/utils/mysql_db_helper.py
+++ b/tanner/utils/mysql_db_helper.py
@@ -87,7 +87,7 @@ class MySQLDBHelper(BaseDBHelper):
                 dump_db_process.wait()
                 restore_db_process.wait()
             except subprocess.CalledProcessError as e:
-                self.logger.error('Error during copying sql database : %s' % e)
+                self.logger.exception('Error during copying sql database : %s' % e)
         return attacker_db
 
     async def insert_dummy_data(self, table_name, data_tokens, cursor):
@@ -116,7 +116,7 @@ class MySQLDBHelper(BaseDBHelper):
             for row in result:
                 tables.append(row[0])
         except Exception as e:
-            self.logger.error('Error during query map creation')
+            self.logger.exception('Error during query map creation')
         else:
             query_map = dict.fromkeys(tables)
             for table in tables:
@@ -134,5 +134,5 @@ class MySQLDBHelper(BaseDBHelper):
                             columns.append(dict(name=row[3], type='TEXT'))
                     query_map[table] = columns
                 except Exception:
-                    self.logger.error('Error during query map creation')
+                    self.logger.exception('Error during query map creation')
         return query_map

--- a/tanner/utils/sqlite_db_helper.py
+++ b/tanner/utils/sqlite_db_helper.py
@@ -74,7 +74,7 @@ class SQLITEDBHelper(BaseDBHelper):
             for row in cursor.execute(select_tables):
                 tables.append(row[0])
         except sqlite3.OperationalError as sqlite_error:
-            self.logger.error('Error during query map creation: %s', sqlite_error)
+            self.logger.exception('Error during query map creation: %s', sqlite_error)
         else:
             query_map = dict.fromkeys(tables)
             for table in tables:
@@ -85,5 +85,5 @@ class SQLITEDBHelper(BaseDBHelper):
                         columns.append(dict(name=row[1], type=row[2]))
                     query_map[table] = columns
                 except sqlite3.OperationalError as sqlite_error:
-                    self.logger.error('Error during query map creation: %s', sqlite_error)
+                    self.logger.exception('Error during query map creation: %s', sqlite_error)
         return query_map

--- a/tanner/web/server.py
+++ b/tanner/web/server.py
@@ -56,7 +56,7 @@ class TannerWebServer:
                 if 'end_time' in applied_filters:
                     applied_filters['end_time'] = float(applied_filters['end_time'])
         except Exception as e:
-            self.logger.error('Filter error : %s' % e)
+            self.logger.exception('Filter error : %s' % e)
             result = 'Invalid filter definition'
         else:
             sessions = await self.api.return_sessions(applied_filters)


### PR DESCRIPTION
This fixes #238 
Instead of using `logging.error`, `logging.exception` has been used. With `logging.error` only the formatted error message would display and the traceback would be thrown away, whereas with `logging.exception` exception info is added to the logging message.