### PR TITLE
[RFI] Disable check of content type

### DIFF
--- a/tanner/emulators/rfi.py
+++ b/tanner/emulators/rfi.py
@@ -83,7 +83,7 @@ class RfiEmulator:
         try:
             async with aiohttp.ClientSession(loop=self._loop) as session:
                 async with session.post(phpox_address, data=script_data) as resp:
-                    rfi_result = await resp.json()
+                    rfi_result = await resp.json(content_type=None)
         except aiohttp.ClientError as client_error:
             self.logger.exception('Error during connection to php sandbox %s', client_error)
         else:


### PR DESCRIPTION
Disable check of content type when getting results from phpox
Fix next error:
```
aiohttp.client_exceptions.ContentTypeError: 0, message='Attempt to decode JSON with unexpected mimetype: text/plain; charset=utf-8'
```
