### PR TITLE
Fixed wp-content regex matching

### DIFF
--- a/tanner/emulators/base.py
+++ b/tanner/emulators/base.py
@@ -88,7 +88,7 @@ class BaseHandler:
         # dummy for wp-content
         if re.match(patterns.WORD_PRESS_CONTENT, path):
             detection = {'name': 'wp-content', 'order': 1}
-        if re.match(patterns.INDEX, path):
+        elif re.match(patterns.INDEX, path):
             detection = {'name': 'index', 'order': 1}
         # check attacks against get parameters
         possible_get_detection = await self.get_emulation_result(session, get_data, self.get_emulators)

--- a/tanner/tests/test_base.py
+++ b/tanner/tests/test_base.py
@@ -84,16 +84,16 @@ class TestBase(unittest.TestCase):
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, data))
 
-        assert_detection = detection = {'name': 'index', 'order': 1}
+        assert_detection = {'name': 'index', 'order': 1}
         self.assertDictEqual(detection, assert_detection)
 
     def test_handle_wp_content(self):
-        data = dict(path='/wp-content',
+        data = dict(path='/wp-content/',
                     cookies={'sess_uuid': '9f82e5d0e6b64047bba996222d45e72c'})
 
         detection = self.loop.run_until_complete(self.handler.handle_get(self.session, data))
 
-        assert_detection = detection = {'name': 'wp-content', 'order': 1}
+        assert_detection = {'name': 'wp-content', 'order': 1}
         self.assertDictEqual(detection, assert_detection)
 
     def test_handle_rfi(self):


### PR DESCRIPTION
- Sometimes `wp-content` path can be matched with regex of `index` path and the `detection` result gets overwrite.
- fixed some tests logic

Should we make these two cases separate(wp-content and index)?