### PR TITLE
SQLI emulator tests

### DIFF
--- a/tanner/emulators/sqli.py
+++ b/tanner/emulators/sqli.py
@@ -6,7 +6,7 @@ from tanner.emulators import mysqli, sqlite
 
 class SqliEmulator:
     def __init__(self, db_name, working_dir):
-        if (TannerConfig.get('SQLI', 'type') == 'MySQL'):
+        if TannerConfig.get('SQLI', 'type') == 'MySQL':
             self.sqli_emulator = mysqli.MySQLIEmulator(db_name)
         else:
             self.sqli_emulator = sqlite.SQLITEEmulator(db_name, working_dir)

--- a/tanner/tests/test_sqli.py
+++ b/tanner/tests/test_sqli.py
@@ -20,6 +20,8 @@ class SqliTest(unittest.TestCase):
         }
         self.handler = sqli.SqliEmulator('test_db', '/tmp/')
         self.filename = '/tmp/db/test_db'
+        os.makedirs(os.path.dirname(self.filename), exist_ok=True)
+        open('/tmp/db/test_db', 'a').close()
         self.handler.query_map = query_map
         self.sess = mock.Mock()
         self.sess.sess_uuid.hex = 'd877339ec415484987b279469167af3d'
@@ -27,6 +29,12 @@ class SqliTest(unittest.TestCase):
     def test_scan(self):
         attack = '1 UNION SELECT 1,2,3,4'
         assert_result = dict(name='sqli', order=2)
+        result = self.handler.scan(attack)
+        self.assertEqual(result, assert_result)
+
+    def test_scan_negative(self):
+        attack = '1 UNION 1,2,3,4'
+        assert_result = None
         result = self.handler.scan(attack)
         self.assertEqual(result, assert_result)
 

--- a/tanner/tests/test_sqli.py
+++ b/tanner/tests/test_sqli.py
@@ -19,6 +19,21 @@ class SqliTest(unittest.TestCase):
         }
         self.handler = sqli.SqliEmulator('test_db', '/tmp/')
         self.handler.query_map = query_map
+        self.sess = mock.Mock()
+        self.sess.sess_uuid.hex = 'd877339ec415484987b279469167af3d'
+
+    def test_scan(self):
+        attack = '1 UNION SELECT 1,2,3,4'
+        assert_result = dict(name='sqli', order=2)
+        result = self.handler.scan(attack)
+        self.assertEqual(result, assert_result)
+
+    def test_handle(self):
+        self.handler.query_map = None
+        attack_params = [dict(id='id', value='1 UNION SELECT 1,2,3,4')]
+        assert_result = dict(value="[1, 2, 3, 4] [1, 'going.1894', 'winterberry2002@yandex.com', 'iFa(|Hs^']", page=True)
+        result = self.loop.run_until_complete(self.handler.handle(attack_params, self.sess))
+        self.assertEqual(assert_result, result)
 
     def test_map_query_id(self):
         attack_value = dict(id='id', value='1\'UNION SELECT 1,2,3,4')

--- a/tanner/tests/test_sqli.py
+++ b/tanner/tests/test_sqli.py
@@ -1,5 +1,6 @@
 import asyncio
 import unittest
+import os
 from unittest import mock
 
 from tanner.emulators import sqli
@@ -18,6 +19,7 @@ class SqliTest(unittest.TestCase):
             'comments': [{'name': 'comment', 'type': 'text'}]
         }
         self.handler = sqli.SqliEmulator('test_db', '/tmp/')
+        self.filename = '/tmp/db/test_db'
         self.handler.query_map = query_map
         self.sess = mock.Mock()
         self.sess.sess_uuid.hex = 'd877339ec415484987b279469167af3d'
@@ -29,9 +31,8 @@ class SqliTest(unittest.TestCase):
         self.assertEqual(result, assert_result)
 
     def test_handle(self):
-        self.handler.query_map = None
         attack_params = [dict(id='id', value='1 UNION SELECT 1,2,3,4')]
-        assert_result = dict(value="[1, 2, 3, 4] [1, 'going.1894', 'winterberry2002@yandex.com', 'iFa(|Hs^']", page=True)
+        assert_result = dict(value="no such table: users", page=True)
         result = self.loop.run_until_complete(self.handler.handle(attack_params, self.sess))
         self.assertEqual(assert_result, result)
 
@@ -72,3 +73,7 @@ class SqliTest(unittest.TestCase):
                         right syntax to use near foo at line 1'
         result = self.loop.run_until_complete(self.handler.get_sqli_result(attack_value, 'foo.db'))
         self.assertEqual(assert_result, result['value'])
+
+    def tearDown(self):
+        if os.path.exists(self.filename):
+            os.remove(self.filename)

--- a/tanner/tests/test_sqlite.py
+++ b/tanner/tests/test_sqlite.py
@@ -11,9 +11,9 @@ class SqliteTest(unittest.TestCase):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(None)
-        self.filename = '/tmp/db/test_db'
+        self.filename = '/tmp/db/test_db_1'
         os.makedirs(os.path.dirname(self.filename), exist_ok=True)
-        open('/tmp/db/test_db', 'a').close()
+        open('/tmp/db/test_db_1', 'a').close()
         # Insert some testing data
         conn = sqlite3.connect(self.filename)
         self.cursor = conn.cursor()
@@ -21,7 +21,7 @@ class SqliteTest(unittest.TestCase):
         self.cursor.execute('INSERT INTO TEST VALUES(0, "test0")')
         conn.commit()
 
-        self.handler = sqlite.SQLITEEmulator('test_db', '/tmp/')
+        self.handler = sqlite.SQLITEEmulator('test_db_1', '/tmp/')
 
     def tearDown(self):
         if os.path.exists(self.filename):
@@ -34,7 +34,7 @@ class SqliteTest(unittest.TestCase):
         self.assertTrue(os.path.exists('/tmp/db/attacker_d877339ec415484987b279469167af3d'))
 
     def test_create_query_map(self):
-        result = self.handler.helper.create_query_map('/tmp/db', 'test_db')
+        result = self.handler.helper.create_query_map('/tmp/db', 'test_db_1')
         assert_result = {'test': [{'name': 'id', 'type': 'INTEGER'}, {'name': 'username', 'type': 'TEXT'}]}
         self.assertEqual(result, assert_result)
 

--- a/tanner/tests/test_sqlite.py
+++ b/tanner/tests/test_sqlite.py
@@ -11,9 +11,9 @@ class SqliteTest(unittest.TestCase):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(None)
-        self.filename = '/tmp/db/test_db_1'
+        self.filename = '/tmp/db/test_db'
         os.makedirs(os.path.dirname(self.filename), exist_ok=True)
-        open('/tmp/db/test_db_1', 'a').close()
+        open('/tmp/db/test_db', 'a').close()
         # Insert some testing data
         conn = sqlite3.connect(self.filename)
         self.cursor = conn.cursor()
@@ -21,7 +21,7 @@ class SqliteTest(unittest.TestCase):
         self.cursor.execute('INSERT INTO TEST VALUES(0, "test0")')
         conn.commit()
 
-        self.handler = sqlite.SQLITEEmulator('test_db_1', '/tmp/')
+        self.handler = sqlite.SQLITEEmulator('test_db', '/tmp/')
 
     def tearDown(self):
         if os.path.exists(self.filename):
@@ -34,7 +34,7 @@ class SqliteTest(unittest.TestCase):
         self.assertTrue(os.path.exists('/tmp/db/attacker_d877339ec415484987b279469167af3d'))
 
     def test_create_query_map(self):
-        result = self.handler.helper.create_query_map('/tmp/db', 'test_db_1')
+        result = self.handler.helper.create_query_map('/tmp/db', 'test_db')
         assert_result = {'test': [{'name': 'id', 'type': 'INTEGER'}, {'name': 'username', 'type': 'TEXT'}]}
         self.assertEqual(result, assert_result)
 


### PR DESCRIPTION
Changes this PR proposes - 
 - Added missing tests for sqli emulator, overall coverage increased.
 - Tests of `sqli.py` and `sqlite.py` are clashing because of making changes in same file `test_db`. So made some changes in `sqlite.py`.  
Is there better way to do this?