### PR TITLE
key format fix

### DIFF
--- a/tanner/api/api.py
+++ b/tanner/api/api.py
@@ -12,7 +12,7 @@ class Api:
     async def return_snares(self):
         query_res = []
         try:
-            query_res = await self.redis_client.smembers('snare_ids', encoding='utf-8')
+            query_res = await self.redis_client.smembers('key:snare_ids', encoding='utf-8')
         except aioredis.ProtocolError as connection_error:
             self.logger.exception('Can not connect to redis %s', connection_error)
         return list(query_res)


### PR DESCRIPTION
I think the key for `smembers` command should be of this format.

Refs - https://github.com/aio-libs/aioredis/blob/e8c33e39558d4cc91cf70dde490d8b330c97dc2e/tests/set_commands_test.py#L190