### PR TITLE
Fix travis error

### DIFF
--- a/docker/phpox/Dockerfile
+++ b/docker/phpox/Dockerfile
@@ -48,4 +48,4 @@ RUN apk -U --no-cache add \
 # Set workdir and start phpsandbox
 USER nobody:nobody
 WORKDIR /opt/phpox
-CMD ["python3.6", "sandbox.py"]
+CMD ["sh", "-c", "python3.6 sandbox.py"]


### PR DESCRIPTION
fix the build error by calling shell directly
`ERROR: for tanner_phpox  Cannot start service tanner_phpox: oci runtime error: container_linux.go:265: starting container process caused "exec: \"python3.6\": executable file not found in $PATH"`

look at the docker docs: https://docs.docker.com/engine/reference/builder/

> Note: Unlike the shell form, the exec form does not invoke a command shell. This means that normal shell processing does not happen. For example, CMD [ "echo", "$HOME" ] will not do variable substitution on $HOME. If you want shell processing then either use the shell form or execute a shell directly, for example: CMD [ "sh", "-c", "echo $HOME" ]. When using the exec form and executing a shell directly, as in the case for the shell form, it is the shell that is doing the environment variable expansion, not docker.