### PR TITLE
Template Injection Dockerfile

### DIFF
--- a/docker/tanner/template_injection/Dockerfile
+++ b/docker/tanner/template_injection/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine
+
+RUN apk -U --no-cache add \
+  python3
+
+RUN pip3 install --upgrade pip && \
+    pip3 install --no-cache-dir \
+    tornado \
+    jinja2 \
+    mako


### PR DESCRIPTION
This is required to build the custom image as part of template injection emulator.

As aiodocker_helper requires the remote path of the dockerfile to build the image, this needs to be merged first.