### PR TITLE
Proper deletion of sessions on shutdown

### DIFF
--- a/tanner/sessions/session_manager.py
+++ b/tanner/sessions/session_manager.py
@@ -76,7 +76,6 @@ class SessionManager:
                 except ValueError:
                     continue
 
-
     async def delete_sessions_on_shutdown(self, redis_client):
         id_for_deletion = list(self.sessions.keys())
 
@@ -86,8 +85,8 @@ class SessionManager:
                 del self.sessions[sess_id]
 
         try:
-            assert len(self.sessions)==0
-        except AssertionError as e:
+            assert len(self.sessions) == 0
+        except AssertionError:
             self.logger.exception("Not all sessions were moved to the storage!")
 
     async def delete_session(self, sess, redis_client):

--- a/tanner/sessions/session_manager.py
+++ b/tanner/sessions/session_manager.py
@@ -67,25 +67,28 @@ class SessionManager:
         return hashlib.md5(sess_id_string.encode()).hexdigest()
 
     async def delete_old_sessions(self, redis_client):
-        id_for_deletion = []
-        for sess_id, session in self.sessions.items():
-            if not session.is_expired():
-                continue
-            is_deleted = await self.delete_session(session, redis_client)
-            if is_deleted:
-                id_for_deletion.append(sess_id)
-
+        id_for_deletion = [sess_id for sess_id, sess in self.sessions.items() if sess.is_expired()]
         for sess_id in id_for_deletion:
-            try:
-                del self.sessions[sess_id]
-            except ValueError:
-                continue
+            is_deleted = await self.delete_session(self.sessions[sess_id], redis_client)
+            if is_deleted:
+                try:
+                    del self.sessions[sess_id]
+                except ValueError:
+                    continue
+
 
     async def delete_sessions_on_shutdown(self, redis_client):
-        for sess_id, sess in self.sessions.items():
-            is_deleted = await self.delete_session(sess, redis_client)
+        id_for_deletion = list(self.sessions.keys())
+
+        for sess_id in id_for_deletion:
+            is_deleted = await self.delete_session(self.sessions[sess_id], redis_client)
             if is_deleted:
                 del self.sessions[sess_id]
+
+        try:
+            assert len(self.sessions)==0
+        except AssertionError as e:
+            self.logger.exception("Not all sessions were moved to the storage!")
 
     async def delete_session(self, sess, redis_client):
         await sess.remove_associated_db()


### PR DESCRIPTION
These changes fix the exception occurs on shutdown
```
^CTraceback (most recent call last):
  File "/usr/local/bin/tanner", line 4, in <module>
    __import__('pkg_resources').run_script('Tanner==0.6.0', 'tanner')
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 661, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 1448, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/local/lib/python3.7/site-packages/Tanner-0.6.0-py3.7.egg/EGG-INFO/scripts/tanner", line 35, in <module>
  File "/usr/local/lib/python3.7/site-packages/Tanner-0.6.0-py3.7.egg/EGG-INFO/scripts/tanner", line 31, in main
  File "/usr/local/lib/python3.7/site-packages/Tanner-0.6.0-py3.7.egg/tanner/server.py", line 145, in start
  File "/usr/local/lib64/python3.7/site-packages/aiohttp/web.py", line 124, in run_app
    loop.run_until_complete(runner.cleanup())
  File "uvloop/loop.pyx", line 1456, in uvloop.loop.Loop.run_until_complete
  File "/usr/local/lib64/python3.7/site-packages/aiohttp/web_runner.py", line 196, in cleanup
    await site.stop()
  File "/usr/local/lib64/python3.7/site-packages/aiohttp/web_runner.py", line 54, in stop
    await self._runner.shutdown()
  File "/usr/local/lib64/python3.7/site-packages/aiohttp/web_runner.py", line 269, in shutdown
    await self._app.shutdown()
  File "/usr/local/lib64/python3.7/site-packages/aiohttp/web_app.py", line 310, in shutdown
    await self.on_shutdown.send(self)
  File "/usr/local/lib64/python3.7/site-packages/aiohttp/signals.py", line 35, in send
    await receiver(*args, **kwargs)  # type: ignore
  File "/usr/local/lib/python3.7/site-packages/Tanner-0.6.0-py3.7.egg/tanner/server.py", line 104, in on_shutdown
  File "/usr/local/lib/python3.7/site-packages/Tanner-0.6.0-py3.7.egg/tanner/sessions/session_manager.py", line 85, in delete_sessions_on_shutdown
RuntimeError: dictionary changed size during iteration
```