### PR TITLE
Update requirements and dockerfile to fix the error state in tests

### DIFF
--- a/docker/tanner/Dockerfile
+++ b/docker/tanner/Dockerfile
@@ -14,6 +14,9 @@ RUN sed -i 's/dl-cdn/dl-2/g' /etc/apk/repositories && \
                linux-headers \
                py3-yarl \
                python3 \
+               postgresql-dev \
+               gcc \
+               musl-dev \
                python3-dev && \
 # Setup Tanner
     git clone --depth=1 https://github.com/mushorg/tanner -b develop /opt/tanner && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ mimesis<3.0.0
 yarl
 redis
 aioredis
+psycopg2
 aiopg
 uvloop
 pymongo


### PR DESCRIPTION
psycopg2 is causing an issue while being installed in the alpine docker image. It is actually the problem with the alpine image(Related Issue: [psycopg2 684](https://github.com/psycopg/psycopg2/issues/684))

So I am hoping that updating our requirements and dockerfile will fix it.

I tested it locally and did had any issues.