### PR TITLE
Include timestamp in HPFeeds reporter

### DIFF
--- a/tanner/reporting/log_hpfeeds.py
+++ b/tanner/reporting/log_hpfeeds.py
@@ -1,5 +1,6 @@
 import traceback
 import json
+from datetime import datetime
 
 import tanner.reporting.hpfeeds as hpfeeds
 

--- a/tanner/reporting/log_hpfeeds.py
+++ b/tanner/reporting/log_hpfeeds.py
@@ -27,6 +27,7 @@ class Reporting:
         return self.connected_state
 
     def create_session(self, session_data):
+        session_data["timestamp"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f")
         event_data = json.dumps(session_data)
         try:
             self.hpc.publish(self.channel, event_data)


### PR DESCRIPTION
Include the same timestamp as in local logs in hpfeeds. 