### PR TITLE
Fix HPFeeds not reconnecting

### DIFF
--- a/tanner/reporting/hpfeeds.py
+++ b/tanner/reporting/hpfeeds.py
@@ -246,6 +246,6 @@ class HPC(object):
 
 def new(host=None, port=10000, ident=None, secret=None, reconnect=True):
     try:
-        return HPC(host, port, ident, secret, reconnect)
+        return HPC(host, port, ident, secret, reconnect=reconnect)
     except Exception:
         raise

--- a/tanner/reporting/hpfeeds.py
+++ b/tanner/reporting/hpfeeds.py
@@ -173,6 +173,8 @@ class HPC(object):
 
             if not self.connected:
                 raise Disconnect()
+        else:
+            logger.warning("Trying to connect, but already connected!")
 
     def close_old(self):
         if self.s:
@@ -227,9 +229,12 @@ class HPC(object):
                 self.send(msgpublish(self.ident, c, data))
             except Disconnect:
                 logger.info("Disconnected from broker (in publish).")
+                self.connected = False
                 if self.reconnect:
                     self.tryconnect()
                 else:
+                    logger.info("Do not reconnect, aborting.")
+                    self.close_old()
                     raise
 
     def close(self):


### PR DESCRIPTION
If the HPFeeds connection broke, for example because there were no messages to be sent for some time, no reconnection attempt was made.

With this fix it works on my server.